### PR TITLE
Update bzip2 tarball URL

### DIFF
--- a/thirdparty/download.sh
+++ b/thirdparty/download.sh
@@ -3,7 +3,7 @@
 declare -A urls=(
 	# Compression
 	["zlib"]="https://zlib.net/zlib-1.2.11.tar.gz"
-	["bzip2"]="http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
+	["bzip2"]="https://ftp.osuosl.org/pub/clfs/conglomeration/bzip2/bzip2-1.0.6.tar.gz"
 	# Images
 	["libpng"]="https://download.sourceforge.net/libpng/libpng-1.6.34.tar.gz"
 	["libjpeg"]="http://www.ijg.org/files/jpegsrc.v9c.tar.gz"


### PR DESCRIPTION
bzip.org is [no longer under the ownership of the bzip maintainers](https://lwn.net/Articles/762264/), and as such its downloads no longer function. This updates the URL to the one [Homebrew uses](https://github.com/Homebrew/homebrew-core/blob/f3d5acb04536344cb10a844e639fc4f73c3bbe72/Formula/bzip2.rb)