### PR TITLE
fix ./build fast

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,9 @@ case "$method" in
 	fast)
 		version=$(cargo pkgid | cut -d '#' -f 2)
 		archive="plato-${version}.zip"
-		info_url="https://github.com/baskerville/plato/releases/tag/${version}"
+		info_url="https://api.github.com/repos/baskerville/plato/releases/tags/${version}"
 		echo "Downloading ${archive}."
-		release_url=$(wget -q -O - "$info_url" | grep -Eo "https[^\"]+files[^\"]+${archive}")
+		release_url=$(wget -q -O - "$info_url" | jq -r ".assets[] | select(.name == \"$archive\").browser_download_url")
 		wget -q "$release_url"
 		unzip "$archive" 'libs/*' 'bin/*' 'hyphenation-patterns/*'
 		rm "$archive"


### PR DESCRIPTION
Since 0.7.1 the release description doesn't contain links to assets.

Note that it adds `jq` as a build dependency though.