### PR TITLE
Link stdc++ to fix build failure from libdjvulibre

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     if env::var("HOST") != env::var("TARGET") {
-        println!("cargo:rustc-flags=-L libs -l jpeg -l png16 -l openjp2 -l jbig2dec -l bz2 -l z -l m");
+        println!("cargo:rustc-flags=-L libs -l jpeg -l png16 -l openjp2 -l jbig2dec -l bz2 -l z -l m -l dylib=stdc++");
         println!("cargo:rustc-env=PKG_CONFIG_ALLOW_CROSS=1");
     }
 }


### PR DESCRIPTION
Feel free to close if this is an error/flagrant misconfiguration on my side. 

Builds only worked on my end after making the code change in this PR. Prior to this, I continually received the message (full below): `/usr/bin/arm-linux-gnueabihf-ld: warning: libstdc++.so.6, needed by libs/libdjvulibre.so, not found (try using -rpath or -rpath-link)`

```
error: linking with `arm-linux-gnueabihf-gcc` failed: exit code: 1
  |
  = note: "arm-linux-gnueabihf-gcc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-L" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.0.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.1.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.10.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.11.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.12.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.13.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.14.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.15.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.2.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.3.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.4.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.5.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.6.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.7.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.8.rcgu.o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.plato.1z1yi8am-cgu.9.rcgu.o" "-o" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/plato-03c8a69f024d06c7.4lkhs952cuqp0b6z.rcgu.o" "-Wl,--gc-sections" "-pie" "-Wl,-zrelro" "-Wl,-znow" "-Wl,-O1" "-nodefaultlibs" "-L" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps" "-L" "/home/welps/dev/rust/plato/target/release/deps" "-L" "libs" "-L" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/build/backtrace-sys-d3aa1f356a465e72/out" "-L" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/build/bzip2-sys-bb427bef519f6eba/out/lib" "-L" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib" "-ldjvulibre" "-lmupdf" "-lmupdfwrapper" "-lharfbuzz" "-lfreetype" "-lmupdf" "-ljpeg" "-lpng16" "-lopenjp2" "-ljbig2dec" "-lbz2" "-lz" "-lm" "-Wl,-Bstatic" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libcrockford-9b3be8278270582b.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libtoml-1d749e14e39ba2d3.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libpng-b9c45a24c39afdb8.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libdeflate-abf20a92b96b0542.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libinflate-668bebd095c7328d.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libbitflags-c3ee698e3951e573.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libdowncast_rs-d1f1c9c71c8bb3ba.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/librand_xorshift-686cc92f75a14685.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libserde_json-4b4bc832a194c4ec.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libryu-987ef2dda5c6f778.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libitoa-adfe67026705b0ca.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libglob-34b9779d84d52351.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/librand-7bdc42cddf2e0792.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/librand_chacha-bf5de11af6862862.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libc2_chacha-1a2c867e07a034f2.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libppv_lite86-66ee2ddc2dfbe0b6.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/librand_core-b1ecdcefef94ba9a.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libgetrandom-d1dbe21c25a408fb.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libunicode_normalization-208c24556761de3f.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libsmallvec-89929e338199dabc.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libseptem-52b9ab9a0f80403f.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libxi_unicode-b85973af8bbf912a.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libparagraph_breaker-7d4d22405386cb9a.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libkl_hyphenate-ddd14a18957902ac.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libhyphenation_commons-70486a5a91e64902.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libbincode-1ccd3b429c5fa8cd.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libbyteorder-921a841a7c18fa8a.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libatlatl-919a1ae989a5d7f9.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libregex-372c930853aa2719.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libthread_local-ad7b4ecd67221ac8.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libregex_syntax-be799097302f09ba.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libaho_corasick-f9a878a7f84d4b58.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libmemchr-38a739887dff392b.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libzip-eb6e84dce6388750.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libpodio-7fa5163b77cb5b79.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libflate2-1d0a65b208415e46.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libminiz_oxide-ab82c84e98b457c3.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libadler32-ad3eb30e05cf3078.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libcrc32fast-fcb7a20b428d1d67.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libbzip2-ffb6b363bd8560bb.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libbzip2_sys-6161db11c6a6a7a4.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libchrono-32449444da35d61d.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libnum_integer-bc5be24a838b8d1f.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libnum_traits-213697516f45a206.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libtime-201966df7ea4cf01.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libentities-756c3a6dae702c90.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libserde-13cdf75b187c5b1b.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libfnv-6e971795abcf6dcf.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libfailure-3b16646b439e0915.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libbacktrace-bd77db399818ba98.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libbacktrace_sys-7533c49fca70274b.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/liblibc-47398c1e3b881650.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/libcfg_if-e8d51f745108570b.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/librustc_demangle-9347e7181e80d080.rlib" "/home/welps/dev/rust/plato/target/arm-unknown-linux-gnueabihf/release/deps/liblazy_static-1f4d2eef09ed0ef1.rlib" "-Wl,--start-group" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libstd-141ed0a5e0e1c2ba.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libpanic_unwind-a72070139220275e.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libhashbrown-093434daf7d99801.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/librustc_std_workspace_alloc-24daf38551b7a03b.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libbacktrace-36d70d9746402ce9.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libbacktrace_sys-7acfc843240167a8.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/librustc_demangle-eb2e0f5fe057b8b3.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libunwind-75e9ddd83715a368.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libcfg_if-af51e7c6fd7d1248.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/liblibc-27f2a77b2995d98c.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/liballoc-ad10152c26711a1e.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/librustc_std_workspace_core-291bd2456cb6c9fe.rlib" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libcore-fc6e9071307a3016.rlib" "-Wl,--end-group" "/home/welps/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libcompiler_builtins-ebe4001ded7f33e7.rlib" "-Wl,-Bdynamic" "-lutil" "-lutil" "-ldl" "-lrt" "-lpthread" "-lgcc_s" "-lc" "-lm" "-lrt" "-lpthread" "-lutil" "-lutil" "-Wl,-rpath-link,/usr/lib"
  = note: /usr/bin/arm-linux-gnueabihf-ld: warning: libstdc++.so.6, needed by libs/libdjvulibre.so, not found (try using -rpath or -rpath-link)
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_free_exception@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_guard_acquire@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_end_catch@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `operator delete(void*)@GLIBCXX_3.4'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `vtable for __cxxabiv1::__si_class_type_info@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_begin_catch@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__gxx_personality_v0@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__aeabi_atexit@CXXABI_ARM_1.3.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_allocate_exception@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `operator delete[](void*)@GLIBCXX_3.4'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_guard_abort@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_rethrow@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `operator new(unsigned int)@GLIBCXX_3.4'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `std::set_new_handler(void (*)())@GLIBCXX_3.4'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `std::terminate()@GLIBCXX_3.4'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `vtable for __cxxabiv1::__vmi_class_type_info@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_pure_virtual@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `vtable for __cxxabiv1::__class_type_info@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_end_cleanup@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_throw@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `__cxa_guard_release@CXXABI_1.3'
          /usr/bin/arm-linux-gnueabihf-ld: libs/libdjvulibre.so: undefined reference to `operator new[](unsigned int)@GLIBCXX_3.4'
          collect2: error: ld returned 1 exit status


error: aborting due to previous error

error: could not compile `plato`.
```