### PR TITLE
Developer quality of life improvements (containerization, vendoring, GitHub CI testing)

### DIFF
--- a/.github/workflows/armhf.yml
+++ b/.github/workflows/armhf.yml
@@ -1,0 +1,13 @@
+name: armhf
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: (armhf) build image
+      run: docker build . -f Dockerfile -t plato:armhf
+    - name: (armhf) build plato
+      run: docker run --rm plato:armhf

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,13 @@
+name: dev
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: (dev) build image
+      run: docker build . -f Dockerfile.dev -t plato:dev
+    - name: (dev) run tests and build all features
+      run: docker run --rm plato:dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
 FROM rust:1.39-buster
 
 RUN /usr/bin/dpkg --add-architecture armhf
-RUN apt-get update && apt-get install -y libtool \
-	automake \
-	pkg-config \
-	cmake \
-	ragel \
-	jq \
-	patchelf \	
-	gcc-arm-linux-gnueabihf \
-	g++-arm-linux-gnueabihf \
-	libfreetype6-dev:armhf \
-	libglib2.0-dev:armhf \
-	libcairo2-dev:armhf \
-	libstdc++6:armhf
+RUN apt-get update && apt-get install -y pkg-config \
+	jq
+
+RUN wget -q --show-progress -O "armf.tar.xz" "https://media.githubusercontent.com/media/kobolabs/Kobo-Reader/master/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz"
+RUN mkdir -p /opt/armf && tar -x --strip-components 1 -C "/opt/armf" -f "armf.tar.xz" && rm "armf.tar.xz"
+RUN find /opt/armf/bin -name 'arm-*' -exec ln -s {} /usr/bin \;
 
 RUN rustup target add arm-unknown-linux-gnueabihf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1.39-buster
+
+RUN /usr/bin/dpkg --add-architecture armhf
+RUN apt-get update && apt-get install -y libtool \
+	automake \
+	pkg-config \
+	cmake \
+	ragel \
+	jq \
+	patchelf \	
+	gcc-arm-linux-gnueabihf \
+	g++-arm-linux-gnueabihf \
+	libfreetype6-dev:armhf \
+	libglib2.0-dev:armhf \
+	libcairo2-dev:armhf \
+	libstdc++6:armhf
+
+RUN rustup target add arm-unknown-linux-gnueabihf
+
+# Build plato
+WORKDIR /plato
+ADD . /plato
+CMD ["./build.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,37 @@
+FROM rust:1.39-buster
+
+RUN apt-get update && apt-get install -y libtool \
+	automake \
+	pkg-config \
+	cmake \
+	ragel \
+	jq \
+	patchelf \	
+	gcc-arm-linux-gnueabihf \
+	g++-arm-linux-gnueabihf \
+	libdjvulibre-dev \
+	libharfbuzz-dev \
+	libcairo2-dev \
+	libstdc++6 \
+	libsdl2-dev \
+ 	# start mupdf dependencies
+	libjbig2dec0-dev \
+	patch
+ 	# end mupdf dependencies
+
+WORKDIR /tmp
+
+# Build modified mupdf and wrapper
+COPY contrib/ /tmp/contrib/
+COPY thirdparty/ /tmp/thirdparty/
+COPY src/wrapper/ /tmp/wrapper/
+RUN wget -qO - "https://mupdf.com/downloads/archive/mupdf-1.16.0-source.tar.gz" | tar -xz --strip-components 1 -C "/tmp/thirdparty/mupdf/" \
+	&& cp /tmp/contrib/linux/mupdf/* /tmp/thirdparty/mupdf/ \
+	&& cd /tmp/thirdparty/mupdf/ && (patch -p1 < linux.patch) && ./build-linux.sh && cp /tmp/thirdparty/mupdf/build/release/libmupdf.so /usr/lib/ \
+	&& cd /tmp/wrapper/ && CFLAGS="-I /tmp/thirdparty/mupdf/include" ./build.sh && cp /tmp/wrapper/libmupdfwrapper.so /usr/lib/
+
+# Build plato
+WORKDIR /plato
+
+ADD . /plato
+CMD ["bash", "-c", "cargo test && cargo build --all-features"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,18 +1,10 @@
 FROM rust:1.39-buster
 
 RUN apt-get update && apt-get install -y libtool \
-	automake \
 	pkg-config \
-	cmake \
-	ragel \
 	jq \
-	patchelf \	
-	gcc-arm-linux-gnueabihf \
-	g++-arm-linux-gnueabihf \
 	libdjvulibre-dev \
 	libharfbuzz-dev \
-	libcairo2-dev \
-	libstdc++6 \
 	libsdl2-dev \
  	# start mupdf dependencies
 	libjbig2dec0-dev \

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     if env::var("HOST") != env::var("TARGET") {
-        println!("cargo:rustc-flags=-L libs -l jpeg -l png16 -l openjp2 -l jbig2dec -l bz2 -l z -l m");
+        println!("cargo:rustc-flags=-L libs -l jpeg -l png16 -l openjp2 -l jbig2dec -l bz2 -l z -l m -l dylib=stdc++");
         println!("cargo:rustc-env=PKG_CONFIG_ALLOW_CROSS=1");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     if env::var("HOST") != env::var("TARGET") {
-        println!("cargo:rustc-flags=-L libs -l jpeg -l png16 -l openjp2 -l jbig2dec -l bz2 -l z -l m -l dylib=stdc++");
+        println!("cargo:rustc-flags=-L libs -l jpeg -l png16 -l openjp2 -l jbig2dec -l bz2 -l z -l m");
         println!("cargo:rustc-env=PKG_CONFIG_ALLOW_CROSS=1");
     }
 }


### PR DESCRIPTION
It can be difficult to contribute to this project due to the underlying C/C++ libraries used by dependencies. The documentation helps, but it's easy to omit libraries that may come standard on some distros (I use arch btw) which can cause frustration for developers when they are trying to get to a working build.

This pull request provides the following enhancements:
- Provide working Dockerfiles for:
    - the target build (armf)
    - development builds
- GitHub Actions to prevent breakages by:
    - building the armf docker image and plato using `./build.sh slow`
    - building the development docker image and running tests
    - note that the time on these builds can be drastically improved by refactoring the steps that add packages from debian into an image that is hosted in a container registry
    - examples: [working armf run](https://github.com/welps/plato/runs/320256158) | [working dev run](https://github.com/welps/plato/runs/320256124) 
- Vendors the `thirdparty/` dependencies
    - This arose because freetype is hosted on savannah.nongnu.org and became inaccessible this weekend due to a disk array failure (see https://hostux.social/@fsfstatus)
- Removes need for developers to maintain their own `.cargo/config` as it is possible to maintain project-specific configuration as documented in https://doc.rust-lang.org/cargo/reference/config.html

I have tested the plato binary on my Kobo Forma that was created in the armf container and did not observe any issues. Note that instantiating the image into a container will just run `./build.sh slow` and if you want to mount the output to your host volume, you can run `docker run -v $(pwd)/target:/plato/target [nameofthecreatedimage]`

Let me know if there are any questions. Thanks so much for your work @baskerville , I really enjoy using plato.