### PR TITLE
Allow directional buttons to be inverted on certain Kobo devices

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -225,6 +225,13 @@ impl Device {
         }
     }
 
+    pub fn should_invert_buttons(&self, rotation: i8) -> bool {
+        let sr = self.startup_rotation();
+        let (_, dir) = self.mirroring_scheme();
+
+        rotation == (4 + sr - dir) % 4 || rotation == (4 + sr - 2 * dir) % 4
+    }
+
     pub fn orientation(&self, rotation: i8) -> Orientation {
         let discriminant = match self.model {
             Model::LibraH2O => 0,
@@ -411,6 +418,21 @@ mod tests {
 
         let device = Device::new("pika", "378");
         assert_eq!(device.has_page_turn_buttons(), false);
+    }
+
+    #[test]
+    fn test_device_should_invert_buttons() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.should_invert_buttons(0), false);
+        assert_eq!(device.should_invert_buttons(1), false);
+        assert_eq!(device.should_invert_buttons(2), true);
+        assert_eq!(device.should_invert_buttons(3), true);
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.should_invert_buttons(0), false);
+        assert_eq!(device.should_invert_buttons(1), true);
+        assert_eq!(device.should_invert_buttons(2), true);
+        assert_eq!(device.should_invert_buttons(3), false);
     }
 
     #[test]

--- a/src/device.rs
+++ b/src/device.rs
@@ -129,6 +129,13 @@ impl Device {
         }
     }
 
+    pub fn has_page_turn_buttons(&self) -> bool {
+        match self.model {
+            Model::Forma | Model::Forma32GB => true,
+            _ => false,
+        }
+    }
+
     pub fn orientation(&self, rotation: i8) -> Orientation {
         let discriminant = match self.model {
             Model::LibraH2O => 0,

--- a/src/device.rs
+++ b/src/device.rs
@@ -131,7 +131,7 @@ impl Device {
 
     pub fn has_page_turn_buttons(&self) -> bool {
         match self.model {
-            Model::Forma | Model::Forma32GB => true,
+            Model::Forma | Model::Forma32GB | Model::LibraH2O => true,
             _ => false,
         }
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -72,7 +72,7 @@ pub struct Device {
     pub dpi: u16,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FrontlightKind {
     Standard,
     Natural,
@@ -80,6 +80,95 @@ pub enum FrontlightKind {
 }
 
 impl Device {
+    pub fn new(product: &str, model_number: &str) -> Device {
+        match product {
+            "kraken" => Device {
+                model: Model::Glo,
+                proto: TouchProto::Single,
+                dims: (758, 1024),
+                dpi: 212,
+            },
+            "pixie" => Device {
+                model: Model::Mini,
+                proto: TouchProto::Single,
+                dims: (600, 800),
+                dpi: 200,
+            },
+            "dragon" => Device {
+                model: Model::AuraHD,
+                proto: TouchProto::Single,
+                dims: (1080, 1440),
+                dpi: 265,
+            },
+            "phoenix" => Device {
+                model: Model::Aura,
+                proto: TouchProto::MultiA,
+                dims: (758, 1024),
+                dpi: 212,
+            },
+            "dahlia" => Device {
+                model: Model::AuraH2O,
+                proto: TouchProto::MultiA,
+                dims: (1080, 1440),
+                dpi: 265,
+            },
+            "alyssum" => Device {
+                model: Model::GloHD,
+                proto: TouchProto::MultiA,
+                dims: (1072, 1448),
+                dpi: 300,
+            },
+            "pika" => Device {
+                model: Model::Touch2,
+                proto: TouchProto::MultiA,
+                dims: (600, 800),
+                dpi: 167,
+            },
+            "daylight" => Device {
+                model: if model_number == "381" { Model::AuraONELimEd } else { Model::AuraONE },
+                proto: TouchProto::MultiA,
+                dims: (1404, 1872),
+                dpi: 300,
+            },
+            "star" => Device {
+                model: if model_number == "379" { Model::AuraEd2V2 } else { Model::AuraEd2V1 },
+                proto: TouchProto::MultiA,
+                dims: (758, 1024),
+                dpi: 212,
+            },
+            "snow" => Device {
+                model: if model_number == "378" { Model::AuraH2OEd2V2 } else { Model::AuraH2OEd2V1 },
+                proto: TouchProto::MultiB,
+                dims: (1080, 1440),
+                dpi: 265,
+            },
+            "nova" => Device {
+                model: Model::ClaraHD,
+                proto: TouchProto::MultiB,
+                dims: (1072, 1448),
+                dpi: 300,
+            },
+            "frost" => Device {
+                model: if model_number == "380" { Model::Forma32GB } else { Model::Forma },
+                proto: TouchProto::MultiB,
+                dims: (1440, 1920),
+                dpi: 300,
+            },
+            "storm" => Device {
+                model: Model::LibraH2O,
+                proto: TouchProto::MultiB,
+                dims: (1264, 1680),
+                dpi: 300,
+            },
+            _ => Device {
+                model: if model_number == "320" { Model::TouchC } else { Model::TouchAB },
+                proto: TouchProto::Single,
+                dims: (600, 800),
+                dpi: 167,
+            },
+        }
+    }
+
     pub fn library_path(&self) -> PathBuf {
         match self.model {
             Model::AuraH2O |
@@ -227,154 +316,227 @@ lazy_static! {
         let product = env::var("PRODUCT").unwrap_or_default();
         let model_number = env::var("MODEL_NUMBER").unwrap_or_default();
 
-        match product.as_ref() {
-            "kraken" => Device {
-                model: Model::Glo,
-                proto: TouchProto::Single,
-                dims: (758, 1024),
-                dpi: 212,
-            },
-            "pixie" => Device {
-                model: Model::Mini,
-                proto: TouchProto::Single,
-                dims: (600, 800),
-                dpi: 200,
-            },
-            "dragon" => Device {
-                model: Model::AuraHD,
-                proto: TouchProto::Single,
-                dims: (1080, 1440),
-                dpi: 265,
-            },
-            "phoenix" => Device {
-                model: Model::Aura,
-                proto: TouchProto::MultiA,
-                dims: (758, 1024),
-                dpi: 212,
-            },
-            "dahlia" => Device {
-                model: Model::AuraH2O,
-                proto: TouchProto::MultiA,
-                dims: (1080, 1440),
-                dpi: 265,
-            },
-            "alyssum" => Device {
-                model: Model::GloHD,
-                proto: TouchProto::MultiA,
-                dims: (1072, 1448),
-                dpi: 300,
-            },
-            "pika" => Device {
-                model: Model::Touch2,
-                proto: TouchProto::MultiA,
-                dims: (600, 800),
-                dpi: 167,
-            },
-            "daylight" => Device {
-                model: if model_number == "381" { Model::AuraONELimEd } else { Model::AuraONE },
-                proto: TouchProto::MultiA,
-                dims: (1404, 1872),
-                dpi: 300,
-            },
-            "star" => Device {
-                model: if model_number == "379" { Model::AuraEd2V2 } else { Model::AuraEd2V1 },
-                proto: TouchProto::MultiA,
-                dims: (758, 1024),
-                dpi: 212,
-            },
-            "snow" => Device {
-                model: if model_number == "378" { Model::AuraH2OEd2V2 } else { Model::AuraH2OEd2V1 },
-                proto: TouchProto::MultiB,
-                dims: (1080, 1440),
-                dpi: 265,
-            },
-            "nova" => Device {
-                model: Model::ClaraHD,
-                proto: TouchProto::MultiB,
-                dims: (1072, 1448),
-                dpi: 300,
-            },
-            "frost" => Device {
-                model: if model_number == "380" { Model::Forma32GB } else { Model::Forma },
-                proto: TouchProto::MultiB,
-                dims: (1440, 1920),
-                dpi: 300,
-            },
-            "storm" => Device {
-                model: Model::LibraH2O,
-                proto: TouchProto::MultiB,
-                dims: (1264, 1680),
-                dpi: 300,
-            },
-            _ => Device {
-                model: if model_number == "320" { Model::TouchC } else { Model::TouchAB },
-                proto: TouchProto::Single,
-                dims: (600, 800),
-                dpi: 167,
-            },
-        }
+        Device::new(&product, &model_number)
     };
 
-// Tuples of the form
-// ((HEIGHT, DPI), (SMALL_HEIGHT, BIG_HEIGHT))
-// SMALL_HEIGHT and BIG_HEIGHT are choosen such that
-// HEIGHT = 3 * SMALL_HEIGHT + k * BIG_HEIGHT where k > 3
-// BIG_HEIGHT / SMALL_HEIGHT is as close as possible to 83/63
-// SMALL_HEIGHT / DPI * 2.54 is as close as possible to 1 cm
-pub static ref BAR_SIZES: HashMap<(u32, u16), (u32, u32)> =
-    [((1920, 300), (120, 156)),
-     ((1440, 300), (126, 177)),
-     ((1872, 300), (126, 166)),
-     ((1404, 300), (126, 171)),
-     ((1264, 300), (123, 179)),
-     ((1680, 300), (120, 165)),
-     ((1448, 300), (121, 155)),
-     ((1072, 300), (124, 175)),
-     ((1440, 265), (104, 141)),
-     ((1080, 265), (110, 150)),
-     ((1024, 212), ( 87, 109)),
-     (( 758, 212), ( 81, 103)),
-     (( 800, 167), ( 66,  86)),
-     (( 600, 167), ( 65,  81)),
-     (( 800, 200), ( 80, 112)),
-     (( 600, 200), ( 84, 116))].iter().cloned().collect();
+    // Tuples of the form
+    // ((HEIGHT, DPI), (SMALL_HEIGHT, BIG_HEIGHT))
+    // SMALL_HEIGHT and BIG_HEIGHT are choosen such that
+    // HEIGHT = 3 * SMALL_HEIGHT + k * BIG_HEIGHT where k > 3
+    // BIG_HEIGHT / SMALL_HEIGHT is as close as possible to 83/63
+    // SMALL_HEIGHT / DPI * 2.54 is as close as possible to 1 cm
+    pub static ref BAR_SIZES: HashMap<(u32, u16), (u32, u32)> =
+        [((1920, 300), (120, 156)),
+         ((1440, 300), (126, 177)),
+         ((1872, 300), (126, 166)),
+         ((1404, 300), (126, 171)),
+         ((1264, 300), (123, 179)),
+         ((1680, 300), (120, 165)),
+         ((1448, 300), (121, 155)),
+         ((1072, 300), (124, 175)),
+         ((1440, 265), (104, 141)),
+         ((1080, 265), (110, 150)),
+         ((1024, 212), ( 87, 109)),
+         (( 758, 212), ( 81, 103)),
+         (( 800, 167), ( 66,  86)),
+         (( 600, 167), ( 65,  81)),
+         (( 800, 200), ( 80, 112)),
+         (( 600, 200), ( 84, 116))].iter().cloned().collect();
 }
 
 #[cfg(test)]
 mod tests {
-    use super::optimal_bars_setup;
+    use std::env;
+    use std::path::PathBuf;
+    use super::{scale_by_dpi, Device, Model, TouchProto};
+    use crate::device::{CURRENT_DEVICE, EXTERNAL_CARD_ROOT, INTERNAL_CARD_ROOT, FrontlightKind, Orientation};
+
+    #[test]
+    fn test_global_static_current_device() {
+        env::set_var("PRODUCT", "frost");
+        env::set_var("MODEL_NUMBER", "380");
+
+        assert_eq!(CURRENT_DEVICE.model, Model::Forma32GB);
+    }
+
+    #[test]
+    fn test_device_library_path() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.library_path(), PathBuf::from(INTERNAL_CARD_ROOT));
+
+        let device = Device::new("kraken", "380");
+        assert_eq!(device.library_path(), PathBuf::from(EXTERNAL_CARD_ROOT));
+    }
+
+    #[test]
+    fn test_device_frontlight_kind() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.frontlight_kind(), FrontlightKind::Premixed);
+
+        let device = Device::new("snow", "378");
+        assert_eq!(device.frontlight_kind(), FrontlightKind::Natural);
+    }
+
+    #[test]
+    fn test_device_has_natural_light() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.has_natural_light(), true);
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.has_natural_light(), false);
+    }
+
+    #[test]
+    fn test_device_has_light_sensor() {
+        let device = Device::new("daylight", "380");
+        assert_eq!(device.has_lightsensor(), true);
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.has_lightsensor(), false);
+    }
+
+    #[test]
+    fn test_device_has_gyroscope() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.has_gyroscope(), true);
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.has_gyroscope(), false);
+    }
+
+    #[test]
+    fn test_device_has_page_turn_buttons() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.has_page_turn_buttons(), true);
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.has_page_turn_buttons(), false);
+    }
+
+    #[test]
+    fn test_device_orientation() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.orientation(0), Orientation::Landscape);
+        assert_eq!(device.orientation(1), Orientation::Portrait);
+
+        let device = Device::new("storm", "378");
+        assert_eq!(device.orientation(0), Orientation::Portrait);
+        assert_eq!(device.orientation(1), Orientation::Landscape);
+    }
+
+    #[test]
+    fn test_device_mark() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.mark(), 7);
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.mark(), 6);
+    }
+
+    #[test]
+    fn test_device_mirroring_scheme() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.mirroring_scheme(), (2, -1));
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.mirroring_scheme(), (2, 1));
+    }
+
+    #[test]
+    fn test_device_should_mirror_axes() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.should_mirror_axes(0), (false, false));
+        assert_eq!(device.should_mirror_axes(1), (true, false));
+        assert_eq!(device.should_mirror_axes(2), (true, true));
+        assert_eq!(device.should_mirror_axes(3), (false, true));
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.should_mirror_axes(0), (false, false));
+        assert_eq!(device.should_mirror_axes(1), (false, true));
+        assert_eq!(device.should_mirror_axes(2), (true, true));
+        assert_eq!(device.should_mirror_axes(3), (true, false));
+    }
+
+    #[test]
+    fn test_device_swapping_scheme() {
+        let device = Device::new("storm", "378");
+        assert_eq!(device.swapping_scheme(), 0);
+
+        let device = Device::new("frost", "380");
+        assert_eq!(device.swapping_scheme(), 1);
+    }
+
+    #[test]
+    fn test_device_should_swap_axes() {
+        let device = Device::new("storm", "378");
+        assert_eq!(device.should_swap_axes(0), true);
+        assert_eq!(device.should_swap_axes(1), false);
+        assert_eq!(device.should_swap_axes(2), true);
+        assert_eq!(device.should_swap_axes(3), false);
+
+        let device = Device::new("frost", "380");
+        assert_eq!(device.should_swap_axes(0), false);
+        assert_eq!(device.should_swap_axes(1), true);
+        assert_eq!(device.should_swap_axes(2), false);
+        assert_eq!(device.should_swap_axes(3), true);
+    }
+
+    #[test]
+    fn test_device_startup_rotation() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.startup_rotation(), 1);
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.startup_rotation(), 3);
+    }
+
+    #[test]
+    fn test_device_transformed_rotation() {
+        let device = Device::new("frost", "380");
+        assert_eq!(device.transformed_rotation(0), 0);
+        assert_eq!(device.transformed_rotation(1), 3);
+        assert_eq!(device.transformed_rotation(2), 2);
+        assert_eq!(device.transformed_rotation(3), 1);
+
+        let device = Device::new("pika", "378");
+        assert_eq!(device.transformed_rotation(0), 0);
+        assert_eq!(device.transformed_rotation(1), 1);
+        assert_eq!(device.transformed_rotation(2), 2);
+        assert_eq!(device.transformed_rotation(3), 3);
+    }
 
     #[test]
     fn bar_sizes() {
         assert_eq!(optimal_bars_setup(1872, 300), (126, 166));
         assert_eq!(optimal_bars_setup(1448, 300), (121, 155));
     }
-}
 
-pub fn optimal_bars_setup(height: u32, dpi: u16) -> (u32, u32) {
-    let target_ratio = 83.0 / 63.0;
-    let target_small_height = scale_by_dpi(126.0, dpi) as u32;
-    let maximum_big_height = 2 * target_small_height;
-    let minimum_small_height = 2 * target_small_height / 3;
-    let mut max_score = 0;
-    let mut result = (0, 0);
-    for small_height in minimum_small_height..=target_small_height {
-        let remaining_height = height - 3 * small_height;
-        for big_height in small_height..maximum_big_height {
-            if remaining_height % big_height == 0 {
-                let ratio = big_height as f32 / small_height as f32;
-                let drift = if ratio > target_ratio {
-                    target_ratio / ratio
-                } else {
-                    ratio / target_ratio
-                };
-                let score = (small_height as f32 * drift) as u32;
-                if score > max_score {
-                    max_score = score;
-                    result = (small_height, big_height);
+    fn optimal_bars_setup(height: u32, dpi: u16) -> (u32, u32) {
+        let target_ratio = 83.0 / 63.0;
+        let target_small_height = scale_by_dpi(126.0, dpi) as u32;
+        let maximum_big_height = 2 * target_small_height;
+        let minimum_small_height = 2 * target_small_height / 3;
+        let mut max_score = 0;
+        let mut result = (0, 0);
+        for small_height in minimum_small_height..=target_small_height {
+            let remaining_height = height - 3 * small_height;
+            for big_height in small_height..maximum_big_height {
+                if remaining_height % big_height == 0 {
+                    let ratio = big_height as f32 / small_height as f32;
+                    let drift = if ratio > target_ratio {
+                        target_ratio / ratio
+                    } else {
+                        ratio / target_ratio
+                    };
+                    let score = (small_height as f32 * drift) as u32;
+                    if score > max_score {
+                        max_score = score;
+                        result = (small_height, big_height);
+                    }
                 }
             }
         }
+        result
     }
-    result
 }
+

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -443,6 +443,9 @@ pub fn run() -> Result<(), Error> {
                         }
                     }
                 },
+                Event::Select(EntryId::SetButtonScheme(button_scheme)) => {
+                    context.settings.button_scheme = button_scheme;
+                },
                 Event::Select(EntryId::ToggleInverted) => {
                     context.fb.toggle_inverted();
                     tx.send(Event::Render(context.fb.rect(), UpdateMode::Gui)).ok();

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -37,6 +37,15 @@ pub enum LinearDir {
     Forward,
 }
 
+impl LinearDir {
+    pub fn opposite(self) -> LinearDir {
+        match self {
+            LinearDir::Backward => LinearDir::Forward,
+            LinearDir::Forward => LinearDir::Backward,
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Point {
     pub x: i32,
@@ -1152,10 +1161,15 @@ impl DivAssign<f32> for Boundary {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use super::divide;
+    use super::{divide, LinearDir};
+
+    #[test]
+    fn test_linear_dir_opposite() {
+        assert_eq!(LinearDir::Forward.opposite(), LinearDir::Backward);
+        assert_eq!(LinearDir::Backward.opposite(), LinearDir::Forward);
+    }
 
     #[test]
     fn overlaping_rectangles() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -144,7 +144,7 @@ impl ButtonCode {
 }
 
 fn resolve_button_direction(mut direction: LinearDir, rotation: i8, button_scheme: ButtonScheme) -> ButtonCode {
-    if (rotation >= 2) ^ (button_scheme == ButtonScheme::Inverted) {
+    if (CURRENT_DEVICE.should_invert_buttons(rotation)) ^ (button_scheme == ButtonScheme::Inverted) {
         direction = direction.opposite();
     }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,5 +1,6 @@
 mod preset;
 
+use std::fmt::{self, Debug};
 use std::path::PathBuf;
 use std::collections::{HashSet, HashMap, BTreeMap};
 use serde::{Serialize, Deserialize};
@@ -37,6 +38,12 @@ pub enum RotationLock {
 pub enum ButtonScheme {
     Natural,
     Inverted,
+}
+
+impl fmt::Display for ButtonScheme {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/view/common.rs
+++ b/src/view/common.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::sync::mpsc;
 use chrono::Local;
 use crate::device::CURRENT_DEVICE;
-use crate::settings::RotationLock;
+use crate::settings::{ButtonScheme, RotationLock};
 use crate::framebuffer::UpdateMode;
 use crate::geom::{Point, Rectangle};
 use super::{View, Event, Hub, ViewId, AppCmd, EntryId, EntryKind};
@@ -108,6 +108,15 @@ pub fn toggle_main_menu(view: &mut dyn View, rect: Rectangle, enable: Option<boo
             entries.push(EntryKind::Command("Start Nickel".to_string(), EntryId::StartNickel));
         } else {
             entries.push(EntryKind::Command("Quit".to_string(), EntryId::Quit));
+        }
+
+        if CURRENT_DEVICE.has_page_turn_buttons() {
+            let button_scheme = context.settings.button_scheme;
+            let button_schemes = vec![
+                EntryKind::RadioButton(ButtonScheme::Natural.to_string(), EntryId::SetButtonScheme(ButtonScheme::Natural), button_scheme == ButtonScheme::Natural),
+                EntryKind::RadioButton(ButtonScheme::Inverted.to_string(), EntryId::SetButtonScheme(ButtonScheme::Inverted), button_scheme == ButtonScheme::Inverted),
+            ];
+            entries.insert(5, EntryKind::SubMenu("Button Scheme".to_string(), button_schemes));
         }
 
         if CURRENT_DEVICE.has_gyroscope() {

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -50,7 +50,7 @@ use fnv::FnvHashMap;
 use downcast_rs::{Downcast, impl_downcast};
 use crate::font::Fonts;
 use crate::document::{Location, TextLocation, TocEntry};
-use crate::settings::{SecondColumn, RotationLock};
+use crate::settings::{ButtonScheme, SecondColumn, RotationLock};
 use crate::metadata::{Info, ZoomMode, SortMethod, TextAlign, SimpleStatus, PageScheme, Margin};
 use crate::geom::{LinearDir, CycleDir, Rectangle, Boundary};
 use crate::framebuffer::{Framebuffer, UpdateMode};
@@ -482,6 +482,7 @@ pub enum EntryId {
     GoTo(usize),
     GoToSelectedPageName,
     SearchDirection(LinearDir),
+    SetButtonScheme(ButtonScheme),
     SetFontFamily(String),
     SetFontSize(i32),
     SetTextAlign(TextAlign),


### PR DESCRIPTION
@baskerville 

This adds the ability to invert the behavior on the direction buttons for the Kobo Forma ~~, I think this is the only Kobo device with buttons at the moment~~ . I've tested it on my Forma and it works.

Due to how the event handling currently flows, I've had to create a pseudo `InputEvent` that gets fed from the main app into the `raw_events` channel so that the `device_events` channel is able to resolve future forward/back events in respect to the `ButtonScheme` setting. I'm not sure if this is kosher since it's not an actual event from `/dev/input/eventX`, but it seems like the cleanest route to take.

I did not opt to have the `ButtonScheme` setting itself visually be a toggle and instead use a list (`Natural`/ `Inverted`). The reason for this is because further down the line, people may want to retain the `Natural` button scheme in certain orientations while using `Inverted` in others. Unless I've gone crazy, it seems that Nickel itself was not handling the button inversion in landscape until the December firmware update.

Let me know if you have any questions or changes, thanks.