### PR TITLE
fixes undefined references to libstdc++ at ld step () with newer toolchains

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,5 +4,6 @@ fn main() {
     if env::var("HOST") != env::var("TARGET") {
         println!("cargo:rustc-flags=-L libs -l jpeg -l png16 -l openjp2 -l jbig2dec -l bz2 -l z -l m");
         println!("cargo:rustc-env=PKG_CONFIG_ALLOW_CROSS=1");
+        println!("cargo:rustc-link-lib=dylib=stdc++");
     }
 }


### PR DESCRIPTION
See #90 
This PR replaces #91 
Third party dependency `libdjvulibre.so` requires linking with the standard c++ library.
Note that the Linaro 4.9.4-2017.01 toolchain seems to automatically link with `libstdc++` which is not the newer toolchains.

Since the Kobo's Linaro toolchain is based around GCC, hardcode stdc++ and ignore Clang's libc++ possibility.