### PR TITLE
Use different refresh rate when screen is inverted

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -216,9 +216,14 @@ pub struct HomeSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
+pub struct RefreshRateSettings {
+    pub regular: u8,
+    pub inverted: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct ReaderSettings {
-    pub refresh_every: u8,
-    pub refresh_every_inverted: u8,
     pub finished: FinishedAction,
     pub font_path: String,
     pub font_family: String,
@@ -226,6 +231,7 @@ pub struct ReaderSettings {
     pub text_align: TextAlign,
     pub margin_width: i32,
     pub line_height: f32,
+    pub refresh_rate: RefreshRateSettings,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -252,11 +258,19 @@ impl Default for HomeSettings {
     }
 }
 
+impl Default for RefreshRateSettings {
+    fn default() -> Self {
+        RefreshRateSettings {
+            regular: 8,
+            inverted: 2,
+        }
+    }
+}
+
 impl Default for ReaderSettings {
     fn default() -> Self {
         ReaderSettings {
-            refresh_every: 8,
-            refresh_every_inverted: 2,
+            refresh_rate: RefreshRateSettings::default(),
             finished: FinishedAction::Notify,
             font_path: DEFAULT_FONT_PATH.to_string(),
             font_family: DEFAULT_FONT_FAMILY.to_string(),

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -218,6 +218,7 @@ pub struct HomeSettings {
 #[serde(default, rename_all = "kebab-case")]
 pub struct ReaderSettings {
     pub refresh_every: u8,
+    pub refresh_every_inverted: u8,
     pub finished: FinishedAction,
     pub font_path: String,
     pub font_family: String,
@@ -255,6 +256,7 @@ impl Default for ReaderSettings {
     fn default() -> Self {
         ReaderSettings {
             refresh_every: 8,
+            refresh_every_inverted: 2,
             finished: FinishedAction::Notify,
             font_path: DEFAULT_FONT_PATH.to_string(),
             font_family: DEFAULT_FONT_FAMILY.to_string(),

--- a/src/view/reader/mod.rs
+++ b/src/view/reader/mod.rs
@@ -910,9 +910,9 @@ impl Reader {
         self.page_turns += 1;
         let update_mode = update_mode.unwrap_or_else(|| {
             let refresh_rate = if context.fb.inverted() {
-                context.settings.reader.refresh_every_inverted
+                context.settings.reader.refresh_rate.inverted
             } else {
-                context.settings.reader.refresh_every
+                context.settings.reader.refresh_rate.regular
             };
             if refresh_rate == 0 || self.page_turns % (refresh_rate as usize) != 0 {
                 UpdateMode::Partial

--- a/src/view/reader/mod.rs
+++ b/src/view/reader/mod.rs
@@ -598,7 +598,7 @@ impl Reader {
         }
     }
 
-    fn page_scroll(&mut self, delta_y: i32, hub: &Hub, _context: &mut Context) {
+    fn page_scroll(&mut self, delta_y: i32, hub: &Hub, context: &mut Context) {
         if delta_y == 0 {
             return;
         }
@@ -646,7 +646,7 @@ impl Reader {
 
         self.view_port.top_offset = next_top_offset;
         self.current_page = location;
-        self.update(None, hub, _context);
+        self.update(None, hub, context);
 
         if location_changed {
             if let Some(ref mut s) = self.search {


### PR DESCRIPTION
Screen inversion can produce a lot of ghosting.
This commit adds a new setting, refresh-every-inverted, which defines
the number of page turns between every full screen refresh whenever
color inversion is enabled.

Design wise, the Reader update method needs an access to the inversion state. Instead of adding two new duplications by having an inverted state boolean in addition to a copy of the refresh_every_inverted value, I decided to somehow give access to the context in update.
It seemed to me that, semantically, the refresh-every* states were part of the context (for now at least, until the reader could maybe change them), the inversion state is less clear (maybe only inverting the text and not the GUI makes sense?) but as long as it's a global framebuffer handled state it's clearly a part of the context, which I decided not to duplicate.

Two choices to make the context available: either have the Reader keep a reference to the context, or have every method recursively take a Context ref. I did not choose the former since that would shadow the 'constness' of the context in some of the methods (per some signatures it needs to be mutable in others); I instead added a context parameter to the update method and to the many callers that did not have one in the first place.

Why adding a new value? Because a growth function, even logarithmic to the "_normal_ full-refresh rate", wouldn't make much sense since the behavior of the screen is really different when inverted. In comparison to paper: black on white ghosting is somewhat similar to recto-verso printing on too thin a paper whereas white on black ghosting looks like misprint and reading becomes dreadful.