### PR TITLE
Sort by file names and paths

### DIFF
--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -170,7 +170,6 @@ pub fn asciify(name: &str) -> String {
         .replace('’', "'")
 }
 
-
 pub fn open<P: AsRef<Path>>(path: P) -> Option<Box<dyn Document>> {
     file_kind(path.as_ref()).and_then(|k| {
         match k.as_ref() {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -340,14 +340,6 @@ impl Info {
         }
     }
 
-    pub fn file_path(&self) -> String {
-        self.file.path.to_string_lossy().into_owned()
-    }
-
-    pub fn file_name(&self) -> String {
-        self.file.path.file_name().unwrap().to_string_lossy().into_owned()
-    }
-
     pub fn file_stem(&self) -> String {
         self.file.path.file_stem().unwrap().to_string_lossy().into_owned()
     }
@@ -578,11 +570,11 @@ pub fn sort_year(i1: &Info, i2: &Info) -> Ordering {
 }
 
 pub fn sort_filename(i1: &Info, i2: &Info) -> Ordering {
-    i1.file_name().cmp(&i2.file_name())
+    i1.file.path.file_name().cmp(&i2.file.path.file_name())
 }
 
 pub fn sort_filepath(i1: &Info, i2: &Info) -> Ordering {
-    i1.file_path().cmp(&i2.file_path())
+    i1.file.path.cmp(&i2.file.path)
 }
 
 lazy_static! {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -340,6 +340,14 @@ impl Info {
         }
     }
 
+    pub fn file_path(&self) -> String {
+        self.file.path.to_string_lossy().into_owned()
+    }
+
+    pub fn file_name(&self) -> String {
+        self.file.path.file_name().unwrap().to_string_lossy().into_owned()
+    }
+
     pub fn file_stem(&self) -> String {
         self.file.path.file_stem().unwrap().to_string_lossy().into_owned()
     }
@@ -452,6 +460,8 @@ pub enum SortMethod {
     Size,
     Kind,
     Pages,
+    FileName,
+    FilePath,
 }
 
 impl SortMethod {
@@ -473,6 +483,8 @@ impl SortMethod {
             SortMethod::Size => "File Size",
             SortMethod::Kind => "File Type",
             SortMethod::Pages => "Pages",
+            SortMethod::FileName => "File Name",
+            SortMethod::FilePath => "File Path",
         }
     }
 
@@ -492,6 +504,8 @@ pub fn sort(md: &mut Metadata, sort_method: SortMethod, reverse_order: bool) {
         SortMethod::Size => sort_size,
         SortMethod::Kind => sort_kind,
         SortMethod::Pages => sort_pages,
+        SortMethod::FileName => sort_filename,
+        SortMethod::FilePath => sort_filepath,
     };
     if reverse_order {
         md.sort_by(|a, b| sort_fn(a, b).reverse());
@@ -508,7 +522,6 @@ pub fn sort_opened(i1: &Info, i2: &Info) -> Ordering {
         (&Some(ref r1), &Some(ref r2)) => r1.opened.cmp(&r2.opened),
     }
 }
-
 
 pub fn sort_pages(i1: &Info, i2: &Info) -> Ordering {
     match (&i1.reader, &i2.reader) {
@@ -558,6 +571,14 @@ pub fn sort_kind(i1: &Info, i2: &Info) -> Ordering {
 
 pub fn sort_year(i1: &Info, i2: &Info) -> Ordering {
     i1.year.cmp(&i2.year)
+}
+
+pub fn sort_filename(i1: &Info, i2: &Info) -> Ordering {
+    i1.file_name().cmp(&i2.file_name())
+}
+
+pub fn sort_filepath(i1: &Info, i2: &Info) -> Ordering {
+    i1.file_path().cmp(&i2.file_path())
 }
 
 lazy_static! {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -467,7 +467,11 @@ pub enum SortMethod {
 impl SortMethod {
     pub fn reverse_order(self) -> bool {
         match self {
-            SortMethod::Author | SortMethod::Title | SortMethod::Kind => false,
+            SortMethod::Author |
+            SortMethod::Title |
+            SortMethod::Kind |
+            SortMethod::FileName |
+            SortMethod::FilePath => false,
             _ => true,
         }
     }

--- a/src/view/home/mod.rs
+++ b/src/view/home/mod.rs
@@ -741,6 +741,12 @@ impl Home {
                                EntryKind::RadioButton("File Type".to_string(),
                                                       EntryId::Sort(SortMethod::Kind),
                                                       self.sort_method == SortMethod::Kind),
+                               EntryKind::RadioButton("File Name".to_string(),
+                                                      EntryId::Sort(SortMethod::FileName),
+                                                      self.sort_method == SortMethod::FileName),
+                               EntryKind::RadioButton("File Path".to_string(),
+                                                      EntryId::Sort(SortMethod::FilePath),
+                                                      self.sort_method == SortMethod::FilePath),
                                EntryKind::Separator,
                                EntryKind::CheckBox("Reverse Order".to_string(),
                                                    EntryId::ReverseOrder, self.reverse_order)];


### PR DESCRIPTION
Adds two sorting methods for the library: by file names and by file paths.
Useful when the library directories and files are neatly named and ordered. Since Plato does not yet reads series metadata information in ePub3 (maybe I'll see if I can do something about that), but file names/paths can (and do, in my case), this can (and is, in my case) currently be the preferred sorting mechanism.

The results can be a bit surprising to look at since the metadata is shown and not the actual file names/paths. Maybe there should be a "Show metadata"/"Show file names" switch somewhere, or always show the metadata and optionally show the file names, or find the space to always show the file path (probably not a good idea).

I'm not happy with what looks like a lot of string copying, but in practice it is fast enough on my Libra. I don't know the rust compiler enough to know what it can and cannot optimize, yet. At some latter point I might take a look into reducing as much as possible the copying of _const_ (but not really since held by `PathBuf`s) text data if that becomes a necessity (on battery backed device it often is for longevity reason, even if somewhat hard to measure). Maybe the multiple sortings of the library could be cached, too.