### PR TITLE
Provides better error messages on json or toml i/o failures.

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -61,25 +61,25 @@ pub fn decode_entities(text: &str) -> Cow<str> {
 
 pub fn load_json<T, P: AsRef<Path>>(path: P) -> Result<T, Error> where for<'a> T: Deserialize<'a> {
     let file = File::open(path.as_ref())
-        .context(format!("Cannot open file '{}'.", path.as_ref().display()))?;
+        .context(format!("'{}': Cannot open file", path.as_ref().display()))?;
     serde_json::from_reader(file)
-        .context(format!("Cannot parse file '{}'.", path.as_ref().display()))
+        .context(format!("'{}': Cannot parse file", path.as_ref().display()))
         .map_err(Into::into)
 }
 
 pub fn save_json<T, P: AsRef<Path>>(data: &T, path: P) -> Result<(), Error> where T: Serialize {
     let file = File::create(path.as_ref())
-        .context(format!("Cannot create data file '{}'.", path.as_ref().display()))?;
+        .context(format!("'{}': Cannot create data file", path.as_ref().display()))?;
     serde_json::to_writer_pretty(file, data)
-        .context(format!("Cannot serialize data to file '{}'.", path.as_ref().display()))
+        .context(format!("'{}': Cannot serialize data to file", path.as_ref().display()))
         .map_err(Into::into)
 }
 
 pub fn load_toml<T, P: AsRef<Path>>(path: P) -> Result<T, Error> where for<'a> T: Deserialize<'a> {
     let s = fs::read_to_string(path.as_ref())
-        .context(format!("Cannot read file '{}'.", path.as_ref().display()))?;
+        .context(format!("'{}': Cannot read file", path.as_ref().display()))?;
     toml::from_str(&s)
-        .context(format!("Cannot parse file '{}'.", path.as_ref().display()))
+        .context(format!("'{}': Cannot parse file", path.as_ref().display()))
         .map_err(Into::into)
 }
 
@@ -87,7 +87,7 @@ pub fn save_toml<T, P: AsRef<Path>>(data: &T, path: P) -> Result<(), Error> wher
     let s = toml::to_string(data)
         .context("Cannot serialize data.")?;
     fs::write(path.as_ref(), &s)
-        .context(format!("Cannot write to file '{}'.", path.as_ref().display()))
+        .context(format!("'{}': Cannot write to file", path.as_ref().display()))
         .map_err(Into::into)
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -63,15 +63,15 @@ pub fn load_json<T, P: AsRef<Path>>(path: P) -> Result<T, Error> where for<'a> T
     let file = File::open(path.as_ref())
         .context(format!("'{}': Cannot open file", path.as_ref().display()))?;
     serde_json::from_reader(file)
-        .context(format!("'{}': Cannot parse file", path.as_ref().display()))
+        .context(format!("'{}': Cannot parse JSON file", path.as_ref().display()))
         .map_err(Into::into)
 }
 
 pub fn save_json<T, P: AsRef<Path>>(data: &T, path: P) -> Result<(), Error> where T: Serialize {
     let file = File::create(path.as_ref())
-        .context(format!("'{}': Cannot create data file", path.as_ref().display()))?;
+        .context(format!("'{}': Cannot create file", path.as_ref().display()))?;
     serde_json::to_writer_pretty(file, data)
-        .context(format!("'{}': Cannot serialize data to file", path.as_ref().display()))
+        .context(format!("'{}': Cannot serialize to JSON file", path.as_ref().display()))
         .map_err(Into::into)
 }
 
@@ -79,13 +79,13 @@ pub fn load_toml<T, P: AsRef<Path>>(path: P) -> Result<T, Error> where for<'a> T
     let s = fs::read_to_string(path.as_ref())
         .context(format!("'{}': Cannot read file", path.as_ref().display()))?;
     toml::from_str(&s)
-        .context(format!("'{}': Cannot parse file", path.as_ref().display()))
+        .context(format!("'{}': Cannot parse TOML content", path.as_ref().display()))
         .map_err(Into::into)
 }
 
 pub fn save_toml<T, P: AsRef<Path>>(data: &T, path: P) -> Result<(), Error> where T: Serialize {
     let s = toml::to_string(data)
-        .context("Cannot serialize data.")?;
+        .context("Cannot convert to TOML format")?;
     fs::write(path.as_ref(), &s)
         .context(format!("'{}': Cannot write to file", path.as_ref().display()))
         .map_err(Into::into)

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -60,23 +60,35 @@ pub fn decode_entities(text: &str) -> Cow<str> {
 }
 
 pub fn load_json<T, P: AsRef<Path>>(path: P) -> Result<T, Error> where for<'a> T: Deserialize<'a> {
-    let file = File::open(path).context("Can't open file.")?;
-    serde_json::from_reader(file).context("Can't parse file.").map_err(Into::into)
+    let file = File::open(path.as_ref())
+        .context(format!("Cannot open file '{}'.", path.as_ref().display()))?;
+    serde_json::from_reader(file)
+        .context(format!("Cannot parse file '{}'.", path.as_ref().display()))
+        .map_err(Into::into)
 }
 
 pub fn save_json<T, P: AsRef<Path>>(data: &T, path: P) -> Result<(), Error> where T: Serialize {
-    let file = File::create(path).context("Can't create data file.")?;
-    serde_json::to_writer_pretty(file, data).context("Can't serialize data to file.").map_err(Into::into)
+    let file = File::create(path.as_ref())
+        .context(format!("Cannot create data file '{}'.", path.as_ref().display()))?;
+    serde_json::to_writer_pretty(file, data)
+        .context(format!("Cannot serialize data to file '{}'.", path.as_ref().display()))
+        .map_err(Into::into)
 }
 
 pub fn load_toml<T, P: AsRef<Path>>(path: P) -> Result<T, Error> where for<'a> T: Deserialize<'a> {
-    let s = fs::read_to_string(path).context("Can't read file.")?;
-    toml::from_str(&s).context("Can't parse file.").map_err(Into::into)
+    let s = fs::read_to_string(path.as_ref())
+        .context(format!("Cannot read file '{}'.", path.as_ref().display()))?;
+    toml::from_str(&s)
+        .context(format!("Cannot parse file '{}'.", path.as_ref().display()))
+        .map_err(Into::into)
 }
 
 pub fn save_toml<T, P: AsRef<Path>>(data: &T, path: P) -> Result<(), Error> where T: Serialize {
-    let s = toml::to_string(data).context("Can't serialize data.")?;
-    fs::write(path, &s).context("Can't write to file.").map_err(Into::into)
+    let s = toml::to_string(data)
+        .context("Cannot serialize data.")?;
+    fs::write(path.as_ref(), &s)
+        .context(format!("Cannot write to file '{}'.", path.as_ref().display()))
+        .map_err(Into::into)
 }
 
 pub fn combine_sort_methods<'a, T, F1, F2>(mut f1: F1, mut f2: F2) -> Box<dyn FnMut(&T, &T) -> Ordering + 'a>


### PR DESCRIPTION
Trying to understand the programs silent expectations is not easy when the only error message given is "Can't open file.", even more so when it is the first contact with the project after successfully building.

This PR adds path information to the failure contexts that are printed by default when the errors are not recovered from.

It uses the ubiquitous GNU error message formatting convention.