### PR TITLE
Restore Dockerfile and GitHub CI flows

### DIFF
--- a/.github/workflows/armhf.yml
+++ b/.github/workflows/armhf.yml
@@ -1,0 +1,13 @@
+name: armhf
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: (armhf) build image
+      run: docker build . -f Dockerfile -t plato:armhf
+    - name: (armhf) build plato
+      run: docker run --rm plato:armhf

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,13 @@
+name: dev
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: (dev) build image
+      run: docker build . -f Dockerfile.dev -t plato:dev
+    - name: (dev) run tests and build all features
+      run: docker run --rm plato:dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@ FROM rust:1.42-buster
 
 RUN /usr/bin/dpkg --add-architecture armhf
 RUN apt-get update && apt-get install -y pkg-config \
+	gcc-arm-linux-gnueabihf \
+	g++-arm-linux-gnueabihf \
 	jq
-
-RUN wget -q --show-progress -O "armf.tar.xz" "https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz"
-RUN mkdir -p /opt/armf && tar -x --strip-components 1 -C "/opt/armf" -f "armf.tar.xz" && rm "armf.tar.xz"
-RUN find /opt/armf/bin -name 'arm-*' -exec ln -s {} /usr/bin \;
 
 RUN rustup target add arm-unknown-linux-gnueabihf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1.39-buster
+FROM rust:1.42-buster
 
 RUN /usr/bin/dpkg --add-architecture armhf
 RUN apt-get update && apt-get install -y pkg-config \
 	jq
 
-RUN wget -q --show-progress -O "armf.tar.xz" "https://media.githubusercontent.com/media/kobolabs/Kobo-Reader/master/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz"
+RUN wget -q --show-progress -O "armf.tar.xz" "https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz"
 RUN mkdir -p /opt/armf && tar -x --strip-components 1 -C "/opt/armf" -f "armf.tar.xz" && rm "armf.tar.xz"
 RUN find /opt/armf/bin -name 'arm-*' -exec ln -s {} /usr/bin \;
 
@@ -12,5 +12,10 @@ RUN rustup target add arm-unknown-linux-gnueabihf
 
 # Build plato
 WORKDIR /plato
+
 ADD . /plato
+
+# Plato requires a specific version of the mupdf dev library for src/mupdf_wrapper
+RUN cd /plato/thirdparty && ./download.sh mupdf
+
 CMD ["./build.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.39-buster
+
+RUN /usr/bin/dpkg --add-architecture armhf
+RUN apt-get update && apt-get install -y pkg-config \
+	jq
+
+RUN wget -q --show-progress -O "armf.tar.xz" "https://media.githubusercontent.com/media/kobolabs/Kobo-Reader/master/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz"
+RUN mkdir -p /opt/armf && tar -x --strip-components 1 -C "/opt/armf" -f "armf.tar.xz" && rm "armf.tar.xz"
+RUN find /opt/armf/bin -name 'arm-*' -exec ln -s {} /usr/bin \;
+
+RUN rustup target add arm-unknown-linux-gnueabihf
+
+# Build plato
+WORKDIR /plato
+ADD . /plato
+CMD ["./build.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,29 +1,26 @@
-FROM rust:1.39-buster
+FROM rust:1.42-buster
 
 RUN apt-get update && apt-get install -y libtool \
-	pkg-config \
-	jq \
-	libdjvulibre-dev \
-	libharfbuzz-dev \
-	libsdl2-dev \
-	# start mupdf dependencies
-	libjbig2dec0-dev \
-	patch
-	# end mupdf dependencies
+        pkg-config \
+        jq \
+        libdjvulibre-dev \
+        libharfbuzz-dev \
+        libsdl2-dev \
+        # start mupdf dependencies
+        libjbig2dec0-dev \
+        patch
+        # end mupdf dependencies
 
-WORKDIR /tmp
+RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list \
+	&& apt-get update \
+	&& apt-get install -y mupdf libmupdf-dev
 
-# Build modified mupdf and wrapper
-COPY contrib/ /tmp/contrib/
-COPY thirdparty/ /tmp/thirdparty/
-COPY src/wrapper/ /tmp/wrapper/
-RUN wget -qO - "https://mupdf.com/downloads/archive/mupdf-1.16.0-source.tar.gz" | tar -xz --strip-components 1 -C "/tmp/thirdparty/mupdf/" \
-	&& cp /tmp/contrib/linux/mupdf/* /tmp/thirdparty/mupdf/ \
-	&& cd /tmp/thirdparty/mupdf/ && (patch -p1 < linux.patch) && ./build-linux.sh && cp /tmp/thirdparty/mupdf/build/release/libmupdf.so /usr/lib/ \
-	&& cd /tmp/wrapper/ && CFLAGS="-I /tmp/thirdparty/mupdf/include" ./build.sh && cp /tmp/wrapper/libmupdfwrapper.so /usr/lib/
+# Referenced in build.rs for mupdf_wrapper
+ENV CARGO_TARGET_OS=linux
 
 # Build plato
 WORKDIR /plato
 
 ADD . /plato
-CMD ["bash", "-c", "cargo test && cargo build --all-features"]
+
+CMD ["bash", "-c", "cd /plato/src/mupdf_wrapper && ./build.sh && cd /plato/ && cargo test && cargo build --all-features"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,29 @@
+FROM rust:1.39-buster
+
+RUN apt-get update && apt-get install -y libtool \
+	pkg-config \
+	jq \
+	libdjvulibre-dev \
+	libharfbuzz-dev \
+	libsdl2-dev \
+	# start mupdf dependencies
+	libjbig2dec0-dev \
+	patch
+	# end mupdf dependencies
+
+WORKDIR /tmp
+
+# Build modified mupdf and wrapper
+COPY contrib/ /tmp/contrib/
+COPY thirdparty/ /tmp/thirdparty/
+COPY src/wrapper/ /tmp/wrapper/
+RUN wget -qO - "https://mupdf.com/downloads/archive/mupdf-1.16.0-source.tar.gz" | tar -xz --strip-components 1 -C "/tmp/thirdparty/mupdf/" \
+	&& cp /tmp/contrib/linux/mupdf/* /tmp/thirdparty/mupdf/ \
+	&& cd /tmp/thirdparty/mupdf/ && (patch -p1 < linux.patch) && ./build-linux.sh && cp /tmp/thirdparty/mupdf/build/release/libmupdf.so /usr/lib/ \
+	&& cd /tmp/wrapper/ && CFLAGS="-I /tmp/thirdparty/mupdf/include" ./build.sh && cp /tmp/wrapper/libmupdfwrapper.so /usr/lib/
+
+# Build plato
+WORKDIR /plato
+
+ADD . /plato
+CMD ["bash", "-c", "cargo test && cargo build --all-features"]

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,8 @@ case "$method" in
 		ln -s libharfbuzz.so.0 libharfbuzz.so
 
 		ln -s libdjvulibre.so.21 libdjvulibre.so
+
+		cd ..
 		;;
 
 	slow)

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -1,6 +1,18 @@
-## Plato
+# Build
 
-### Preliminary
+Start by cloning the repo:
+
+1. `git clone https://github.com/baskerville/plato.git`
+2. `cd plato`
+
+There are two ways to build plato:
+- [Local Rust Setup](#local)
+- [With Docker/Podman](#docker)
+
+## Local
+
+### Plato
+#### Preliminary
 
 Install the appropriate [compiler toolchain](https://github.com/kobolabs/Kobo-Reader/tree/master/toolchain) (the binaries of the `bin` directory need to be in your path).
 
@@ -19,8 +31,6 @@ rustup target add arm-unknown-linux-gnueabihf
 ### Build phase
 
 ```sh
-git clone https://github.com/baskerville/plato.git
-cd plato
 ./build.sh
 ```
 
@@ -49,3 +59,27 @@ You can install the importer with:
 ```sh
 ./install-importer.sh
 ```
+
+## Docker
+
+### Plato
+
+1. Build the image for armhf: `docker build . -t plato:armhf`
+2. The following compiles, mounts a local volume, and outputs the `plato` binary to your local folder `target/arm-unknown-linux-gnueabihf`:
+
+```
+docker run --rm -t -v $(pwd)/target:/plato/target plato:armhf
+```
+
+You can copy the binary to your Kobo device (make sure you install an existing release first) and it will run.
+
+### Emulator and importer
+
+1. Build the image for dev environments: `docker build . -f Dockerfile.dev -t plato:dev`
+2. The following runs tests, compiles, mounts a local volume, and outputs all binaries to your local folder `target/debug`
+```
+docker run --rm -t -v $(pwd):/plato plato:dev
+```
+
+If the emulator or importer fail to run, please follow the steps in [Local - Emulator and Importer](#emulator-and-importer) to ensure you have the relevant libraries.
+


### PR DESCRIPTION
Here are the relevant changes:

- `thirdparty/download.sh` now takes an argument to allow download of a single package
    - This is done to allow the `armhf` image to be in sync with the necessary `mupdf` version 
- The `dev` image pulls `mupdf@1.16.1` from the `debian:testing` repository
- Added documentation to the `BUILD` markdown to give context on how to use both `Dockerfile` versions

I tested both images, was able to copy the binary generated in the `armhf` container into my Kobo and verify it was working. Emulator works after being built in the `dev` container.

Feel free to notify me in the future for any breakages/updates that need to happen in this area. I am particularly vested in this product (which again, is fantastic) and want to make it easier for other developers to contribute while ensuring breakages are caught through GitHub Actions/CI. Thanks.