### PR TITLE
Add USB Product ID for Kobo Forma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42-buster
+FROM rust:1.43-stretch
 
 RUN /usr/bin/dpkg --add-architecture armhf
 RUN apt-get update && apt-get install -y pkg-config \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rust:1.42-buster
+FROM rust:1.43-buster
 
 RUN apt-get update && apt-get install -y libtool \
         pkg-config \

--- a/launchers/fmon/plato.sh
+++ b/launchers/fmon/plato.sh
@@ -9,8 +9,35 @@ killall -TERM nickel hindenburg sickel fickel fmon > /dev/null 2>&1
 
 grep -q ' /mnt/sd .*[ ,]ro[ ,]' /proc/mounts && mount -o remount,rw /mnt/sd
 
-MODEL_NUMBER=$(cut -f 6 -d ',' /mnt/onboard/.kobo/version | sed -e 's/^[0-]*//')
-export MODEL_NUMBER
+# Define environment variables used by `scripts/usb-*.sh`
+KOBO_TAG=/mnt/onboard/.kobo/version
+if [ -e "$KOBO_TAG" ] ; then
+	SERIAL_NUMBER=$(cut -f 1 -d ',' "$KOBO_TAG")
+	FIRMWARE_VERSION=$(cut -f 3 -d ',' "$KOBO_TAG")
+	MODEL_NUMBER=$(cut -f 6 -d ',' "$KOBO_TAG" | sed -e 's/^[0-]*//')
+
+	# Taken from `KSM09/adds/kbmenu/onstart/ksmhome.sh`
+	case "$MODEL_NUMBER" in
+		310|320) PRODUCT_ID=0x4163 ;;
+		330) PRODUCT_ID=0x4173 ;;
+		340) PRODUCT_ID=0x4183 ;;
+		350) PRODUCT_ID=0x4193 ;;
+		360) PRODUCT_ID=0x4203 ;;
+		370) PRODUCT_ID=0x4213 ;;
+		371) PRODUCT_ID=0x4223 ;;
+		372) PRODUCT_ID=0x4224 ;;
+		373) PRODUCT_ID=0x4225 ;;
+		374) PRODUCT_ID=0x4227 ;;
+		375) PRODUCT_ID=0x4226 ;;
+		376) PRODUCT_ID=0x4228 ;;
+		377) PRODUCT_ID=0x4229 ;;
+		381) PRODUCT_ID=0x4225 ;;
+		*) PRODUCT_ID=0x6666 ;;
+	esac
+
+	export SERIAL_NUMBER FIRMWARE_VERSION MODEL_NUMBER PRODUCT_ID
+fi
+
 export LD_LIBRARY_PATH="libs:${LD_LIBRARY_PATH}"
 
 [ -e info.log ] && [ "$(stat -c '%s' info.log)" -gt $((1<<18)) ] && mv info.log archive.log

--- a/launchers/standalone/plato.sh
+++ b/launchers/standalone/plato.sh
@@ -40,6 +40,7 @@ if [ -e "$KOBO_TAG" ] ; then
 		374) PRODUCT_ID=0x4227 ;;
 		375) PRODUCT_ID=0x4226 ;;
 		376) PRODUCT_ID=0x4228 ;;
+		377) PRODUCT_ID=0x4229 ;;
 		381) PRODUCT_ID=0x4225 ;;
 		*) PRODUCT_ID=0x6666 ;;
 	esac


### PR DESCRIPTION
Hey, I love the new changes to the library. Thanks for your hard work.

I noticed Calibre would not recognize my Kobo Forma when I enabled USB via plato. 

1. Added Kobo Forma's `PRODUCT_ID`, see below for output from device for your own records
2. Updated `fmon` launcher script which was not setting the proper env vars for the `usb-*` scripts
3. I know you don't use them, but the `docker` images have been updated to `rust 1.43`. The `armhf` image is being set to Debian Stretch while `dev` remains on Debian Buster. Buster is on `glibc 2.28` and compiling plato to load onto the Kobo returns the error below so I've reverted it to stretch which is on `glibc 2.24`. 
    ```
    ./plato: /lib/libm.so.6: version `GLIBC_2.27' not found (required by ./plato)
    ./plato: /lib/libc.so.6: version `GLIBC_2.28' not found (required by ./plato)
    ```

   Let me know if this potentially breaks anything.

----
**Output of `/mnt/onboard/.kobo/version`**

`N782890004803,4.1.15,4.20.14622,4.1.15,4.1.15,00000000-0000-0000-0000-000000000377`

**Output of `lsusb -v` for kobo device**
```
Bus 001 Device 009: ID 2237:4229 Kobo Inc. eReader-4.20.14622
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            0
  bDeviceSubClass         0
  bDeviceProtocol         0
  bMaxPacketSize0        64
  idVendor           0x2237 Kobo Inc.
  idProduct          0x4229
  bcdDevice            4.01
  iManufacturer           3 Kobo
  iProduct                4 eReader-4.20.14622
  iSerial                 5 N782890004803
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x0020
    bNumInterfaces          1
    bConfigurationValue     1
    iConfiguration          0
    bmAttributes         0xc0
      Self Powered
    MaxPower                2mA
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           2
      bInterfaceClass         8 Mass Storage
      bInterfaceSubClass      6 SCSI
      bInterfaceProtocol     80 Bulk-Only
      iInterface              1 Mass Storage
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x81  EP 1 IN
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               0
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x01  EP 1 OUT
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               1
Device Qualifier (for other device speed):
  bLength                10
  bDescriptorType         6
  bcdUSB               2.00
  bDeviceClass            0
  bDeviceSubClass         0
  bDeviceProtocol         0
  bMaxPacketSize0        64
  bNumConfigurations      1
Device Status:     0x0001
  Self Powered
```