### PR TITLE
Some startup script fixes following 0.8.6

### DIFF
--- a/contrib/nickel.sh
+++ b/contrib/nickel.sh
@@ -2,7 +2,12 @@
 
 export LD_LIBRARY_PATH=/usr/local/Kobo
 
-( usleep 400000; /etc/init.d/on-animator.sh ) &
+(
+	if [ "${PLATFORM}" = "freescale" ] || [ "${PLATFORM}" = "mx50-ntx" ] || [ "${PLATFORM}" = "mx6sl-ntx" ]; then
+		usleep 400000
+	fi
+	/etc/init.d/on-animator.sh
+) &
 
 # Nickel wants the WiFi to be down when it starts
 ./scripts/wifi-disable.sh

--- a/contrib/plato.sh
+++ b/contrib/plato.sh
@@ -18,7 +18,7 @@ if [ "$PLATO_STANDALONE" ] ; then
 	echo "dc 0" > "$LEDS_INTERFACE"
 else
 	# shellcheck disable=SC2046
-	export $(grep -sE '^(INTERFACE|WIFI_MODULE|WIFI_MODULE_PATH|DBUS_SESSION_BUS_ADDRESS|NICKEL_HOME|LANG)=' /proc/"$(pidof nickel)"/environ)
+	export $(grep -sE '^(INTERFACE|WIFI_MODULE|WIFI_MODULE_PATH|DBUS_SESSION_BUS_ADDRESS|NICKEL_HOME|LANG)=' /proc/"$(pidof -s nickel)"/environ)
 	sync
 	killall -TERM nickel hindenburg sickel fickel adobehost fmon > /dev/null 2>&1
 fi

--- a/contrib/plato.sh
+++ b/contrib/plato.sh
@@ -18,7 +18,7 @@ if [ "$PLATO_STANDALONE" ] ; then
 	echo "dc 0" > "$LEDS_INTERFACE"
 else
 	# shellcheck disable=SC2046
-	export $(grep -sE '^(INTERFACE|WIFI_MODULE|DBUS_SESSION_BUS_ADDRESS|NICKEL_HOME|LANG)=' /proc/"$(pidof nickel)"/environ)
+	export $(grep -sE '^(INTERFACE|WIFI_MODULE|WIFI_MODULE_PATH|DBUS_SESSION_BUS_ADDRESS|NICKEL_HOME|LANG)=' /proc/"$(pidof nickel)"/environ)
 	sync
 	killall -TERM nickel hindenburg sickel fickel adobehost fmon > /dev/null 2>&1
 fi

--- a/contrib/plato.sh
+++ b/contrib/plato.sh
@@ -18,7 +18,7 @@ if [ "$PLATO_STANDALONE" ] ; then
 	echo "dc 0" > "$LEDS_INTERFACE"
 else
 	# shellcheck disable=SC2046
-	export $(grep -sE '^(INTERFACE|WIFI_MODULE|DBUS_SESSION|NICKEL_HOME|LANG)=' /proc/"$(pidof nickel)"/environ)
+	export $(grep -sE '^(INTERFACE|WIFI_MODULE|DBUS_SESSION_BUS_ADDRESS|NICKEL_HOME|LANG)=' /proc/"$(pidof nickel)"/environ)
 	sync
 	killall -TERM nickel hindenburg sickel fickel fmon > /dev/null 2>&1
 fi

--- a/contrib/plato.sh
+++ b/contrib/plato.sh
@@ -20,7 +20,7 @@ else
 	# shellcheck disable=SC2046
 	export $(grep -sE '^(INTERFACE|WIFI_MODULE|DBUS_SESSION_BUS_ADDRESS|NICKEL_HOME|LANG)=' /proc/"$(pidof nickel)"/environ)
 	sync
-	killall -TERM nickel hindenburg sickel fickel fmon > /dev/null 2>&1
+	killall -TERM nickel hindenburg sickel fickel adobehost fmon > /dev/null 2>&1
 fi
 
 # Remount the SD card read-write if it's mounted read-only


### PR DESCRIPTION
c.f., https://github.com/baskerville/plato/commit/31a6247d870b1d8502d4f5505cc5bf4d6aab1b79#r39393129

This most likely fixes WiFi handling, as well as the RMSDK on restart.