### PR TITLE
Update to mupdf 1.17.0 on plato:dev image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,9 +11,15 @@ RUN apt-get update && apt-get install -y libtool \
         patch
         # end mupdf dependencies
 
-RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list \
-	&& apt-get update \
-	&& apt-get install -y mupdf libmupdf-dev
+# TODO:: Remove when mupdf 1.17.0 is available 
+# https://packages.debian.org/source/testing/mupdf
+RUN cd /tmp \
+	&& wget -q "https://mupdf.com/downloads/archive/mupdf-1.17.0-source.tar.xz" -O - | tar -xJ \
+	&& cd /tmp/mupdf-1.17.0-source \
+	&& make build=release libs apps \
+	&& make build=release prefix=usr install \
+	&& find usr/include usr/share usr/lib -type f -exec chmod 0644 {} + \
+	&& cp -r usr/* /usr/
 
 # Referenced in build.rs for mupdf_wrapper
 ENV CARGO_TARGET_OS=linux


### PR DESCRIPTION
Related: #110 

Was able to compile and run the emulator. 

![emulator image](https://user-images.githubusercontent.com/677680/84306179-25898600-ab29-11ea-8d47-4a0da0eb73ad.png)

