### PR TITLE
Interacting with 'Chapter' text on bottom bar should open table of contents?

### DIFF
--- a/src/view/reader/bottom_bar.rs
+++ b/src/view/reader/bottom_bar.rs
@@ -1,5 +1,5 @@
 use crate::framebuffer::{Framebuffer, UpdateMode};
-use crate::view::{View, Event, Hub, Bus, Align};
+use crate::view::{View, Event, Hub, Bus, Align, ViewId};
 use crate::view::icon::Icon;
 use crate::view::filler::Filler;
 use crate::view::label::Label;
@@ -49,9 +49,10 @@ impl BottomBar {
                          .and_then(|toc| doc.chapter(current_page, toc))
                          .map(|c| c.title.clone())
                          .unwrap_or_default();
-        let chapter_label = Label::new(chapter_rect,
+        let mut chapter_label = Label::new(chapter_rect,
                                        chapter,
                                        Align::Center);
+        chapter_label = chapter_label.event(Option::Some(Event::Show(ViewId::TableOfContents)));
         children.push(Box::new(chapter_label) as Box<dyn View>);
 
         let page_label = PageLabel::new(rect![pt!(rect.max.x - side - big_half_width, rect.min.y),


### PR DESCRIPTION
For reference, here's Nickel: 

![image](https://user-images.githubusercontent.com/677680/85061019-24350a80-b174-11ea-931e-c427c2b2437f.png)

I've opted to just allow interaction with the "Chapter ..." text to open the table of contents. This introduces a redundant interaction as the TOC icon remains where it is, but moving the TOC icon next to the "Chapter" text creates some usability awkwardness due to the left navigation arrow on the bottom bar.

For me though, my "trained" behavior is to press on the "Chapter" text to switch chapters so it's weird when it doesn't do anything. 

![plato gif](https://media.giphy.com/media/iJ22IjP45Bbbuajlyz/giphy.gif)