### PR TITLE
Fix dictionary indexing bug and add tests

### DIFF
--- a/src/dictionary/indexing.rs
+++ b/src/dictionary/indexing.rs
@@ -194,6 +194,14 @@ pub fn parse_index<B: BufRead>(mut br: B, lazy: bool) -> Result<Index<B>, DictEr
             break;
         }
         let (headword, offset, size, original) = parse_line(line.trim_end(), line_number)?;
+
+        entries.push(Entry {
+            headword: headword.to_string(),
+            offset,
+            size,
+            original: original.map(String::from),
+        });
+
         if lazy {
             if !info && (headword.starts_with("00-database-") || headword.starts_with("00database")) {
                 info = true;
@@ -201,12 +209,6 @@ pub fn parse_index<B: BufRead>(mut br: B, lazy: bool) -> Result<Index<B>, DictEr
                 break;
             }
         }
-        entries.push(Entry {
-            headword: headword.to_string(),
-            offset,
-            size,
-            original: original.map(String::from),
-        });
         line_number += 1;
         line.clear();
     }
@@ -225,4 +227,116 @@ pub fn parse_index_from_file<P: AsRef<Path>>(path: P, lazy: bool) -> Result<Inde
     let file = File::open(path)?;
     let reader = BufReader::new(file);
     parse_index(reader, lazy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Empty;
+
+    const PATH_CASE_SENSITIVE_INDEX: &str = "src/dictionary/testdata/case_sensitive_dict.index";
+    const PATH_CASE_INSENSITIVE_INDEX: &str = "src/dictionary/testdata/case_insensitive_dict.index";
+
+    #[test]
+    fn test_index_find() {
+        let words = vec![
+            Entry{
+                headword: String::from("bar"),
+                offset: 0,
+                size: 8,
+                original: None,
+            },
+            Entry{
+                headword: String::from("baz"),
+                offset: 8,
+                size: 4,
+                original: None,
+            },
+            Entry{
+                headword: String::from("foo"),
+                offset: 12,
+                size: 4,
+                original: None,
+            },
+        ];
+
+        let index: Index<Empty> = Index{
+            entries: words,
+            state: None,
+        };
+
+        let r = index.find("apples", false);
+        assert!(r.is_empty());
+
+        let r = index.find("baz", false);
+        assert!(!r.is_empty());
+        assert_eq!(r.len(), 1);
+        assert_eq!(r.first().unwrap().headword, "baz");
+
+        let r = index.find("bas", true);
+        assert!(!r.is_empty());
+        assert_eq!(r.len(), 2);
+        assert_eq!(r.first().unwrap().headword, "bar");
+    }
+
+    #[test]
+    // Make sure that a lazy load does not inadvertently skip a word when it returns to BufRead
+    fn test_index_load_and_find() {
+        let r = parse_index_from_file(PATH_CASE_INSENSITIVE_INDEX, true);
+        assert!(r.is_ok());
+
+        let mut index = r.unwrap();
+        assert_eq!(index.entries[0].headword, "00-database-allchars");
+        assert_eq!(index.entries.last().unwrap().headword, "bar");
+
+        let r = index.load_and_find("bar", false, &Metadata{ all_chars: true, case_sensitive: false });
+        assert!(!r.is_empty());
+
+        let r = index.load_and_find("foo", false, &Metadata{ all_chars: true, case_sensitive: false });
+        assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn test_parse_index_from_file() {
+        let r = parse_index_from_file(PATH_CASE_INSENSITIVE_INDEX, false);
+        assert!(r.is_ok());
+
+        let index = r.unwrap();
+        assert_eq!(index.entries[0].headword, "00-database-allchars");
+        assert_eq!(index.entries.last().unwrap().headword, "あいおい");
+    }
+
+    #[test]
+    fn test_parse_index_from_file_lazy() {
+        let r = parse_index_from_file(PATH_CASE_INSENSITIVE_INDEX, true);
+        assert!(r.is_ok());
+
+        let index = r.unwrap();
+        assert_eq!(index.entries[0].headword, "00-database-allchars");
+        assert_eq!(index.entries.last().unwrap().headword, "bar");
+    }
+
+    #[test]
+    fn test_parse_index_from_file_handles_case_insensitivity() {
+        let r = parse_index_from_file(PATH_CASE_INSENSITIVE_INDEX, false);
+        assert!(r.is_ok());
+
+        let index = r.unwrap();
+
+        let r = index.find("bar", false);
+        assert!(!r.is_empty());
+        assert_eq!(r.first().unwrap().headword, "bar");
+    }
+
+    #[test]
+    fn test_parse_index_from_file_handles_case_sensitivity() {
+        let r = parse_index_from_file(PATH_CASE_SENSITIVE_INDEX, false);
+        assert!(r.is_ok());
+
+        let index = r.unwrap();
+
+        let r = index.find("Bar", false);
+        assert!(!r.is_empty());
+        assert_eq!(r.first().unwrap().headword, "Bar");
+    }
 }

--- a/src/dictionary/mod.rs
+++ b/src/dictionary/mod.rs
@@ -116,3 +116,86 @@ pub fn load_dictionary(content: Box<dyn DictReader>, index: Box<dyn IndexReader>
     let case_sensitive = !index.find(word, false).is_empty();
     Dictionary { content, index, metadata: Metadata { all_chars, case_sensitive } }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PATH_CASE_SENSITIVE_DICT: &str = "src/dictionary/testdata/case_sensitive_dict.dict";
+    const PATH_CASE_SENSITIVE_INDEX: &str = "src/dictionary/testdata/case_sensitive_dict.index";
+    const PATH_CASE_INSENSITIVE_DICT: &str = "src/dictionary/testdata/case_insensitive_dict.dict";
+    const PATH_CASE_INSENSITIVE_INDEX: &str = "src/dictionary/testdata/case_insensitive_dict.index";
+
+    fn assert_dict_word_exists(mut dict: Dictionary, headword: &str, definition: &str) -> Dictionary {
+        let r = dict.lookup(headword, false);
+        assert!(r.is_ok());
+        let search = r.unwrap();
+        assert_eq!(search.len(), 1);
+        assert!(search[0][1].contains(definition));
+
+        dict
+    }
+
+    #[test]
+    fn test_load_dictionary_from_file() {
+
+        let r = load_dictionary_from_file(PATH_CASE_INSENSITIVE_DICT, PATH_CASE_INSENSITIVE_INDEX);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn test_dictionary_lookup_case_insensitive() {
+
+        let r = load_dictionary_from_file(PATH_CASE_INSENSITIVE_DICT, PATH_CASE_INSENSITIVE_INDEX);
+        let mut dict = r.unwrap();
+
+        dict = assert_dict_word_exists(dict, "bar", "test for case-sensitivity");
+        dict = assert_dict_word_exists(dict, "Bar", "test for case-sensitivity");
+        dict = assert_dict_word_exists(dict, "straße", "test for non-latin case-sensitivity");
+    }
+
+    #[test]
+    fn test_dictionary_lookup_case_insensitive_fuzzy() {
+
+        let r = load_dictionary_from_file(PATH_CASE_INSENSITIVE_DICT, PATH_CASE_INSENSITIVE_INDEX);
+        let mut dict = r.unwrap();
+
+        let r = dict.lookup("ba", true);
+        assert!(r.is_ok());
+        let search = r.unwrap();
+        assert_eq!(search.len(), 1);
+        assert_eq!(search[0][0], "bar");
+        assert!(search[0][1].contains("test for case-sensitivity"));
+    }
+
+    #[test]
+    fn test_dictionary_lookup_case_sensitive() {
+
+        let r = load_dictionary_from_file(PATH_CASE_SENSITIVE_DICT, PATH_CASE_SENSITIVE_INDEX);
+        let mut dict = r.unwrap();
+
+        dict = assert_dict_word_exists(dict, "Bar", "test for case-sensitivity");
+        dict = assert_dict_word_exists(dict, "straße", "test for non-latin case-sensitivity");
+
+        let r = dict.lookup("bar", false);
+        assert!(r.unwrap().is_empty());
+
+        let r = dict.lookup("strasse", false);
+        assert!(r.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_dictionary_lookup_case_sensitive_fuzzy() {
+
+        let r = load_dictionary_from_file(PATH_CASE_SENSITIVE_DICT, PATH_CASE_SENSITIVE_INDEX);
+        let mut dict = r.unwrap();
+
+        let r = dict.lookup("Ba", true);
+        assert!(r.is_ok());
+        let search = r.unwrap();
+        assert_eq!(search.len(), 1);
+        assert_eq!(search[0][0], "Bar");
+        assert!(search[0][1].contains("test for case-sensitivity"));
+    }
+}
+

--- a/src/dictionary/testdata/case_insensitive_dict.dict
+++ b/src/dictionary/testdata/case_insensitive_dict.dict
@@ -1,0 +1,26 @@
+
+
+00-database-dictfmt-1.12.1
+00-database-short
+     Test Dict
+This file was converted from the original database on:
+          Fri Jun 12 12:16:13 2020
+
+The original data is available from:
+     unknown
+
+The original data was distributed with the notice shown below. No
+additional restrictions are claimed.  Please redistribute this changed
+version under the same conditions and restriction that apply to the
+original version.
+
+foo
+definition
+Bar
+test for case-sensitivity
+あいおい
+test for non-latin characters
+straße
+test for non-latin case-sensitivity
+unknown
+abeforstßあいお

--- a/src/dictionary/testdata/case_insensitive_dict.index
+++ b/src/dictionary/testdata/case_insensitive_dict.index
@@ -1,0 +1,11 @@
+00-database-allchars	B	B
+00-database-alphabet	I4	U
+00-database-dictfmt-1.12.1	C	b
+00-database-info	+	Fu
+00-database-short	d	h
+00-database-url	Iw	I
+00-database-utf8	A	B
+bar	G7	e
+foo	Gs	P
+straße	IE	s
+あいおい	HZ	r

--- a/src/dictionary/testdata/case_sensitive_dict.dict
+++ b/src/dictionary/testdata/case_sensitive_dict.dict
@@ -1,0 +1,27 @@
+
+
+
+00-database-dictfmt-1.12.1
+00-database-short
+     Case Sensitive Test Dict
+This file was converted from the original database on:
+          Fri Jun 12 15:24:14 2020
+
+The original data is available from:
+     unknown
+
+The original data was distributed with the notice shown below. No
+additional restrictions are claimed.  Please redistribute this changed
+version under the same conditions and restriction that apply to the
+original version.
+
+foo
+definition
+Bar
+test for case-sensitivity
+あいおい
+test for non-latin characters
+straße
+test for non-latin case-sensitivity
+unknown
+Baeforstßあいお

--- a/src/dictionary/testdata/case_sensitive_dict.index
+++ b/src/dictionary/testdata/case_sensitive_dict.index
@@ -1,0 +1,12 @@
+00-database-allchars	B	B
+00-database-alphabet	JI	U
+00-database-case-sensitive	C	B
+00-database-dictfmt-1.12.1	D	b
+00-database-info	BO	Fu
+00-database-short	e	w
+00-database-url	JA	I
+00-database-utf8	A	B
+Bar	HL	e
+foo	G8	P
+straße	IU	s
+あいおい	Hp	r


### PR DESCRIPTION
Thank you for addressing the sensitivity issue in 27570e6eb4131cd593578b6d33dcb3de5f977c5e . I understand your choice to follow precedent and not take in case folding.

This PR includes some of the work from my initial PR as I did address a bug where the initial metadata indexing loses a word from triggering the end-of-metadata condition. More importantly, I added tests that'll help prevent future regressions.


