### PR TITLE
Derive parent from canonicalized path for hook working directory

### DIFF
--- a/src/view/home/mod.rs
+++ b/src/view/home/mod.rs
@@ -1086,10 +1086,11 @@ impl Home {
     }
 
     fn spawn_child(&mut self, dir: &Path, program: &PathBuf, wifi: bool, online: bool, hub: &Hub) -> Result<Child, Error> {
-        let parent = program.parent()
-                            .unwrap_or_else(|| Path::new(""));
         let path = program.canonicalize()?;
-        let mut process = Command::new(path)
+        let parent = path.parent()
+                            .unwrap_or_else(|| Path::new(""));
+
+        let mut process = Command::new(&path)
                                  .current_dir(parent)
                                  .arg(dir)
                                  .arg(wifi.to_string())


### PR DESCRIPTION
I'm starting to work with plato hooks and [just opened a PR for wallabako to accommodate the plato v0.8.5 library change](https://gitlab.com/anarcat/wallabako/-/merge_requests/8).

I kept getting a `No such file or directory (os error 2)` when executing the hook, but I *think* that it stemmed from a relative path being sent into `current_dir`. Regardless, the recommendation for [Command.current_dir](https://doc.rust-lang.org/std/process/struct.Command.html#method.current_dir) is to use a canonicalized path.
