### PR TITLE
Allow fetchers to send events for library CleanUp and Import

### DIFF
--- a/doc/HOOKS.md
+++ b/doc/HOOKS.md
@@ -32,6 +32,10 @@ Each event is a JSON object with a required `type` key:
 {"type": "addDocument", "info": OBJECT}
 // Enable or disable the WiFi.
 {"type": "setWifi", "enable": BOOL}
+// Remove entries from library that no longer exist
+{"type": "cleanUp"}
+// Import new entries and update existing entries in library
+{"type": "import"}
 ```
 
 On *Plato*'s side, the events are read line by line, one event per line.

--- a/src/view/home/mod.rs
+++ b/src/view/home/mod.rs
@@ -1123,6 +1123,12 @@ impl Home {
                                     hub2.send(Event::SetWifi(enable)).ok();
                                 }
                             },
+                            Some("cleanUp") => {
+                                hub2.send(Event::Select(EntryId::CleanUp)).ok();
+                            },
+                            Some("import") => {
+                                hub2.send(Event::Select(EntryId::Import)).ok();
+                            },
                             _ => (),
                         }
                     }

--- a/src/view/home/mod.rs
+++ b/src/view/home/mod.rs
@@ -208,6 +208,8 @@ impl Home {
             self.terminate_fetchers(&old_path, hub);
         }
 
+        context.library.flush();
+
         let selected_library = context.settings.selected_library;
         for hook in &context.settings.libraries[selected_library].hooks {
             if context.library.home.join(&hook.path) == path {


### PR DESCRIPTION
This PR adds the following:

1. The library should be flushed prior to hook execution as they might utilize the library metadata
    - We bake this into the "Toggle Select" call since this seems to be the latest we can do this without running into borrowing mutability/immutability conflicts or having to feed it through a channel and racing against the hook execution

2. Allow hooks/fetchers to pass events that force library cleanup and/or import
    - It feels like it would be convenient to have plato do this automatically after any fetcher/hook, but I don't really know what kind of hooks people actually run so an opt-in situation is probably better.

