### PR TITLE
Add current_uri to ReaderInfo

### DIFF
--- a/scripts/nickel-import.py
+++ b/scripts/nickel-import.py
@@ -1,0 +1,105 @@
+#!/usr/local/env python3
+
+"""Import reading status from Kobo Nickel's database to Plato.
+
+WORK IN PROGRESS. This script really doesn't have enough error checking. This
+may corrupt your Plato reading status database.
+
+Currently only supports importing status for .kepub.epub files but may actually
+work with .epub files too.
+"""
+
+from pathlib import Path
+import sqlite3
+import json
+import urllib.parse
+from datetime import datetime
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--force", help="force replacement of newer reading states", action='store_true')
+parser.add_argument("root", help="the path to the mounted Kobo storage")
+args = parser.parse_args()
+
+root = Path(args.root)
+
+print(FORCE)
+with root.joinpath('.metadata.json').open() as f:
+    metadata_json = json.load(f)
+    plato_books = {v["file"]["path"]: k for k, v in metadata_json.items()}
+
+connection = sqlite3.connect(root.joinpath('.kobo/KoboReader.sqlite'))
+cursor = connection.cursor()
+cursor.execute("""
+    select
+        ContentID,
+        Title,
+        ChapterIDBookmarked,
+        adobe_location,
+        ReadStatus,
+        ___PercentRead,
+        DateLastRead
+    from content
+    where
+        BookID is null;""")
+bookmarks = cursor.fetchall()
+
+for ContentID, Title, ChapterIDBookmarked, adobe_location, ReadStatus, PercentRead, DateLastRead in bookmarks:
+    if DateLastRead:
+        # Timezone is always Zulu (I think)
+        # TODO: actually investigate this timestamp
+        kobo_last_read = datetime.strptime(DateLastRead, "%Y-%m-%dT%H:%M:%S%z").replace(tzinfo=None)
+    else:
+        kobo_last_read = None
+
+    parsed_uri = urllib.parse.urlparse(ContentID)
+
+    if parsed_uri.scheme == "file":
+        # TODO: handle /mnt/sd too
+        book = Path(parsed_uri.path).relative_to('/mnt/onboard')
+
+        if not ChapterIDBookmarked:
+            print("SKIPPING book without ChapterIDBookmarked", ContentID)
+            continue
+
+        # TODO: support/test with plain .epub
+        # TODO: support PDF
+        if not book.name.endswith('.kepub.epub'):
+            print("SKIPPING non kepub", ContentID)
+            continue
+
+        if not book.as_posix() in plato_books:
+            print("SKIPPING missing Plato book", ContentID)
+            continue
+
+        # Is it always safe to decode the fingerprint id like this?
+        fingerprint = f"{int(plato_books[book.as_posix()]):X}"
+        # .reading-states should always exist if Plato has been opened
+        reading_state_path = root.joinpath(".reading-states", fingerprint + ".json")
+
+        state = {}
+        if reading_state_path.exists():
+            with reading_state_path.open("r") as f:
+                state = json.load(f)
+                plato_last_read = datetime.strptime(state["opened"], "%Y-%m-%d %H:%M:%S")
+                if(plato_last_read >= kobo_last_read and state["currentPage"] != 0):
+                    if not FORCE:
+                        print("SKIPPING newer Plato reading_state", ContentID)
+                        continue
+                    else:
+                        print("FORCE UPDATING newer Plato reading_state", ContentID)
+
+        last_read = kobo_last_read or datetime.now()
+        state["opened"] = last_read.strftime("%Y-%m-%d %H:%M:%S")
+        state["currentUri"] = ChapterIDBookmarked
+        state["finished"] = ReadStatus == 2 #TODO: test
+        # Fake the page count from the percent read:
+        state["currentPage"] = PercentRead or 0
+        state["pagesCount"] = 100
+
+        with reading_state_path.open("w") as f:
+            json.dump(state, f, indent=2)
+    else:
+        # An adobe digital editions book
+        # TODO: I think adobe_location is used?
+        print("SKIPPING Adobe book", ContentID)

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -226,6 +226,8 @@ pub struct ReaderInfo {
     pub bookmarks: BTreeSet<usize>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub annotations: Vec<Annotation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_uri: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
@@ -262,6 +264,7 @@ impl Default for ReaderInfo {
             page_names: BTreeMap::new(),
             bookmarks: BTreeSet::new(),
             annotations: Vec::new(),
+            current_uri: None
         }
     }
 }

--- a/src/view/reader/mod.rs
+++ b/src/view/reader/mod.rs
@@ -255,7 +255,7 @@ impl Reader {
             let mut view_port = ViewPort::default();
             let mut contrast = Contrast::default();
             let pages_count = doc.pages_count();
-            let current_page;
+            let mut current_page;
 
             // TODO: use get_or_insert_with?
             if let Some(ref mut r) = info.reader {
@@ -269,6 +269,12 @@ impl Reader {
 
                 current_page = doc.resolve_location(Location::Exact(r.current_page))
                                   .unwrap_or(first_location);
+
+                // href overrides current_page if present
+                if let Some(current_uri) = &r.current_uri {
+                    current_page = doc.resolve_location(Location::Uri(current_uri.to_string())).unwrap_or(current_page);
+                    r.current_uri = None;
+                }
 
                 if let Some(zoom_mode) = r.zoom_mode {
                     view_port.zoom_mode = zoom_mode;


### PR DESCRIPTION
`current_uri` is interpreted as an `Location::Uri`. If present, `current_uri` overrides `current_page`. Only read only support is implemented, `current_uri` is cleared immediately allowing `current_page` to be used when the document is next opened.

The Kobo Nickel database stores URIs like `OEBPS/file0025.xhtml#kobo.637.2` in the `ChapterIDBookmarked` field of the `content` table of `KoboReader.sqlite`. This allows exporting the reading status from Nickel to Plato.

A percent read value like 75% can be converted to `current_page`: 75 and `pages_count`: 100 until the document is opened and the correct values are populated.

TODO:
* [ ] Only supports/tested with KEPUBs from Nickel
    * Maybe epubs work too, not sure, untested
    * PDFs have these URIs, maybe they could be supported too: `file:///mnt/onboard/.kobo/guide/userguide.pdf#(0)#pdfloc(e77e,0)`
    * Adobe digital editions books aren't supported, but Plato doesn't support them either
* [ ] Only tested with EPUBs in Plato
    * Only EPUBs actually support `Location::Uri`. This would probably work with HTML too, but it [only supports `Location::LocalUri`](https://github.com/baskerville/plato/blob/96f7e01ff7aa1da045c478debc52e1fa1803db32/src/document/html/mod.rs#L322-L324)

The `nickel-import.py` script is very WIP and probably needs a lot more error checking. I'm not sure if you want a script like that in this repo either. I can remove the second commit if you would like.