### PR TITLE
Remove "starts_with" check

### DIFF
--- a/src/document/epub/mod.rs
+++ b/src/document/epub/mod.rs
@@ -445,16 +445,14 @@ impl EpubDocument {
     fn chapter_aux<'a>(&mut self, toc: &'a [TocEntry], offset: usize, next_offset: usize, path: &str, chap_before: &mut Option<&'a TocEntry>, offset_before: &mut usize, chap_after: &mut Option<&'a TocEntry>, offset_after: &mut usize) {
         for entry in toc {
             if let Location::Uri(ref uri) = entry.location {
-                if uri.starts_with(path) {
-                    if let Some(entry_offset) = self.resolve_location(entry.location.clone()) {
-                        if entry_offset < offset && (chap_before.is_none() || entry_offset > *offset_before) {
-                            *chap_before = Some(entry);
-                            *offset_before = entry_offset;
-                        }
-                        if entry_offset >= offset && entry_offset < next_offset && (chap_after.is_none() || entry_offset < *offset_after) {
-                            *chap_after = Some(entry);
-                            *offset_after = entry_offset;
-                        }
+                if let Some(entry_offset) = self.resolve_location(entry.location.clone()) {
+                    if entry_offset < offset && (chap_before.is_none() || entry_offset > *offset_before) {
+                        *chap_before = Some(entry);
+                        *offset_before = entry_offset;
+                    }
+                    if entry_offset >= offset && entry_offset < next_offset && (chap_after.is_none() || entry_offset < *offset_after) {
+                        *chap_after = Some(entry);
+                        *offset_after = entry_offset;
                     }
                 }
             }


### PR DESCRIPTION
This is my humble attemp to fix #145 after some digging.

The issue is that for the document described in #145, not every epub HTML files (eg. `part0007_split_001.html`) are indexed by the TOC. For example, we don't have a `TocEntry` for every "spine" chunk. As a result, those uri who doesn't have a corresponding `TocEntry` will fail the "starts_with" check, and the current chapter cannot be determined.

I verified the fix on the emulator (launched via `./run-emulator.sh`). However, I am not sure if getting rid of the `uri.starts_with(path)` check will cause any other issues.