### PR TITLE
Add `wifi-{pre,post}-{up,down}.sh` scripts

### DIFF
--- a/contrib/wifi-hooks/wifi-post-up.sh
+++ b/contrib/wifi-hooks/wifi-post-up.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Dropbear can generate a host key automatically (-R), but the file location is
+# configured at build-time and many ARM builds of dropbear have weird locations.
+# In order to specify a location, we need to generate the key manually.
+if [ ! -f /etc/dropbear/dropbear_ecdsa_host_key ]; then
+	mkdir -p /etc/dropbear
+	/mnt/onboard/.adds/bin/dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key
+fi
+
+# add `-n` to skip password check, for initial user creation or password setting
+/mnt/onboard/.adds/bin/dropbear -r /etc/dropbear/dropbear_ecdsa_host_key -p 2233

--- a/contrib/wifi-hooks/wifi-pre-down.sh
+++ b/contrib/wifi-hooks/wifi-pre-down.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+killall dropbear

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -16,6 +16,8 @@ The hyphenation bounds for a particular language can be overridden by creating a
 
 Dictionaries in the *StarDict* and *dictd* formats can be placed in the `dictionaries` directory. *Plato* doesn't support *StarDict* natively and will therefore convert all the *StarDict* dictionaries it might find in the `dictionaries` directory during startup. You can disable this behavior by uncommenting the corresponding line in `config.sh`.
 
+The four scripts `scripts/wifi-{pre,post}-{up,down}.sh` can be customized with commands to run before or after the WiFi is enabled or disabled, respectively.
+
 ## Upgrade
 
 Install the corresponding one-click package on top of the previous one. Check out the [release notes](https://github.com/baskerville/plato/releases) before upgrading: manual intervention might be required.

--- a/scripts/wifi-disable.sh
+++ b/scripts/wifi-disable.sh
@@ -2,6 +2,10 @@
 
 lsmod | grep -q sdio_wifi_pwr || exit 1
 
+SCRIPTS_DIR=$(dirname "$(realpath "$0")")
+PRE_DOWN_SCRIPT=$SCRIPTS_DIR/wifi-pre-down.sh
+[ -f "$PRE_DOWN_SCRIPT" ] && $PRE_DOWN_SCRIPT
+
 killall udhcpc default.script wpa_supplicant 2> /dev/null
 
 [ "$WIFI_MODULE" != 8189fs ] && [ "$WIFI_MODULE" != 8192es ] && wlarm_le -i "$INTERFACE" down
@@ -10,3 +14,6 @@ ifconfig "$INTERFACE" down
 sleep 0.2
 rmmod "$WIFI_MODULE"
 rmmod sdio_wifi_pwr
+
+POST_DOWN_SCRIPT=$SCRIPTS_DIR/wifi-post-down.sh
+[ -f "$POST_DOWN_SCRIPT" ] && $POST_DOWN_SCRIPT

--- a/scripts/wifi-enable.sh
+++ b/scripts/wifi-enable.sh
@@ -2,6 +2,10 @@
 
 lsmod | grep -q sdio_wifi_pwr && exit 1
 
+SCRIPTS_DIR=$(dirname "$(realpath "$0")")
+PRE_UP_SCRIPT=$SCRIPTS_DIR/wifi-pre-up.sh
+[ -f "$PRE_UP_SCRIPT" ] && $PRE_UP_SCRIPT
+
 insmod /drivers/"${PLATFORM}"/wifi/sdio_wifi_pwr.ko
 insmod /drivers/"${PLATFORM}"/wifi/"${WIFI_MODULE}".ko
 
@@ -18,3 +22,6 @@ ifconfig "$INTERFACE" up
 pidof wpa_supplicant > /dev/null || wpa_supplicant -D wext -s -i "$INTERFACE" -c /etc/wpa_supplicant/wpa_supplicant.conf -C /var/run/wpa_supplicant -B
 
 udhcpc -S -i "$INTERFACE" -s /etc/udhcpc.d/default.script -t15 -T10 -A3 -b -q > /dev/null &
+
+POST_UP_SCRIPT=$SCRIPTS_DIR/wifi-post-up.sh
+[ -f "$POST_UP_SCRIPT" ] && $POST_UP_SCRIPT


### PR DESCRIPTION
These scripts are invoked by `wifi-enable.sh` and `wifi-disable.sh`.

My use case is to enable/disable an SSH server.

I am not sure the absolute path `/mnt/onboard/.adds/plato/` is correct for all devices, but I do see that path used in other places in this repo.