### PR TITLE
Set selected-library for emulator

### DIFF
--- a/run-emulator.sh
+++ b/run-emulator.sh
@@ -2,6 +2,7 @@
 
 if ! [ -e Settings.toml ]; then
 	cat <<- EOF > Settings.toml
+	selected-library = 0
 	[[libraries]]
 	name = "Example"
 	path = "$PWD"


### PR DESCRIPTION
Without an explicit `selected-library = 0` in Settings.toml, the
emulator will default to using 1 (at least on my machine) which causes
an out-of-bounds panic since only one `[[libraries]]` section is
specified.

Ensure the single, 0-indexed library is selected to prevent the panic.