### PR TITLE
Bump rust version in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM buildpack-deps:stretch
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.50.0
+    RUST_VERSION=1.52.1
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rust:1.48-buster
+FROM rust:1.52.1-buster
 
 RUN apt-get update && apt-get install -y libtool \
         pkg-config \


### PR DESCRIPTION
Newer versions of Plato require features that were only stabilized in
recent versions of rust.  Bump the versions used in within the
Dockerfiles so they can build current Plato.