### PR TITLE
Add configuration options for south and west strips

### DIFF
--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -81,6 +81,12 @@ finished = "close"
 # The action triggered when tapping the south-east corner.
 # Possible values: "go-to-page", "next-page".
 south-east-corner = "go-to-page"
+# The action triggered when tapping the south strip.
+# Possible values: "toggle-bars", "next-page".
+south-strip-action = "toggle-bars"
+# The action triggered when tapping the west strip.
+# Possible values: "previous-page", "next-page".
+west-strip-action = "previous-page"
 # The width ratio, relative to `min(W, H) / 2`, of the strip and corner touch regions.
 # Launch the *Touch Events* application to display the current touch regions.
 strip-width = 0.6

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -312,6 +312,8 @@ pub struct RefreshRateSettings {
 pub struct ReaderSettings {
     pub finished: FinishedAction,
     pub south_east_corner: SouthEastCornerAction,
+    pub south_strip: SouthStripAction,
+    pub west_strip: WestStripAction,
     pub strip_width: f32,
     pub corner_width: f32,
     pub font_path: String,
@@ -353,6 +355,20 @@ pub enum SouthEastCornerAction {
     GoToPage,
 }
 
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SouthStripAction {
+    ToggleBars,
+    NextPage,
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WestStripAction {
+    PreviousPage,
+    NextPage,
+}
+
 impl Default for RefreshRateSettings {
     fn default() -> Self {
         RefreshRateSettings {
@@ -387,6 +403,8 @@ impl Default for ReaderSettings {
         ReaderSettings {
             finished: FinishedAction::Close,
             south_east_corner: SouthEastCornerAction::GoToPage,
+            south_strip: SouthStripAction::ToggleBars,
+            west_strip: WestStripAction::PreviousPage,
             strip_width: 0.6,
             corner_width: 0.4,
             font_path: DEFAULT_FONT_PATH.to_string(),

--- a/src/view/reader/mod.rs
+++ b/src/view/reader/mod.rs
@@ -39,7 +39,7 @@ use crate::view::search_bar::SearchBar;
 use crate::view::keyboard::Keyboard;
 use crate::view::menu::{Menu, MenuKind};
 use crate::view::notification::Notification;
-use crate::settings::{guess_frontlight, FinishedAction, SouthEastCornerAction};
+use crate::settings::{guess_frontlight, FinishedAction, SouthEastCornerAction, SouthStripAction, WestStripAction};
 use crate::settings::{DEFAULT_FONT_FAMILY, DEFAULT_TEXT_ALIGN, DEFAULT_LINE_HEIGHT, DEFAULT_MARGIN_WIDTH};
 use crate::settings::{HYPHEN_PENALTY, STRETCH_TOLERANCE};
 use crate::frontlight::LightLevels;
@@ -3020,7 +3020,14 @@ impl View for Reader {
                         match dir {
                             Dir::West => {
                                 if self.search.is_none() {
-                                    self.go_to_neighbor(CycleDir::Previous, hub, rq, context);
+                                    match context.settings.reader.west_strip {
+                                        WestStripAction::PreviousPage => {
+                                            self.go_to_neighbor(CycleDir::Previous, hub, rq, context);
+                                        }
+                                        WestStripAction::NextPage => {
+                                            self.go_to_neighbor(CycleDir::Next, hub, rq, context);
+                                        }
+                                    }
                                 } else {
                                     self.go_to_results_neighbor(CycleDir::Previous, hub, rq, context);
                                 }
@@ -3032,7 +3039,15 @@ impl View for Reader {
                                     self.go_to_results_neighbor(CycleDir::Next, hub, rq, context);
                                 }
                             },
-                            Dir::South | Dir::North => self.toggle_bars(None, hub, rq, context),
+                            Dir::South => match context.settings.reader.south_strip {
+                                SouthStripAction::ToggleBars => {
+                                    self.toggle_bars(None, hub, rq, context);
+                                }
+                                SouthStripAction::NextPage => {
+                                    self.go_to_neighbor(CycleDir::Next, hub, rq, context);
+                                }
+                            },
+                            Dir::North => self.toggle_bars(None, hub, rq, context),
                         }
                     },
                     Region::Center => self.toggle_bars(None, hub, rq, context),


### PR DESCRIPTION
Add "south-strip-action" and "west-strip-action" configuration options
(with possible values "toggle-bars", "next-page" and "previous-page",
"next-page" respectively).
Their default actions retain their previous behavior.

This allows a reader to configure Plato such that a tap along any of the
west, south, or east strips advances to the next page.  This allows that
common action to be performed easily irrespective of how the reader is
holding their device.

Note: if the west strip is configured to go to the next page then reader
can still navigate to the previous page with a easterly swipe.