### PR TITLE
Turn off LED even when not in standalone mode

### DIFF
--- a/contrib/plato.sh
+++ b/contrib/plato.sh
@@ -17,19 +17,19 @@ if [ "$PLATO_STANDALONE" ] ; then
 		REM_TRIES=$((REM_TRIES-1))
 		usleep 400000
 	done
-
-	# Turn off the blinking LEDs
-	# https://www.tablix.org/~avian/blog/archives/2013/03/blinken_kindle/
-	LEDS_INTERFACE=/sys/devices/platform/pmic_light.1/lit
-	echo "ch 4" > "$LEDS_INTERFACE"
-	echo "cur 0" > "$LEDS_INTERFACE"
-	echo "dc 0" > "$LEDS_INTERFACE"
 else
 	# shellcheck disable=SC2046
 	export $(grep -sE '^(INTERFACE|WIFI_MODULE|DBUS_SESSION_BUS_ADDRESS|NICKEL_HOME|LANG)=' /proc/"$(pidof -s nickel)"/environ)
 	sync
 	killall -TERM nickel hindenburg sickel fickel adobehost fmon > /dev/null 2>&1
 fi
+
+# Turn off the blinking LEDs
+# https://www.tablix.org/~avian/blog/archives/2013/03/blinken_kindle/
+LEDS_INTERFACE=/sys/devices/platform/pmic_light.1/lit
+echo "ch 4" > "$LEDS_INTERFACE"
+echo "cur 0" > "$LEDS_INTERFACE"
+echo "dc 0" > "$LEDS_INTERFACE"
 
 # Remount the SD card read-write if it's mounted read-only
 grep -q ' /mnt/sd .*[ ,]ro[ ,]' /proc/mounts && mount -o remount,rw /mnt/sd


### PR DESCRIPTION
Disable the charging indicator LED even if Plato isn't being run in
standalone mode.

This ensures that even if the device was charging when Plato was
started, the LED will still be turned off.  This is important because
Plato will not turn the LED off itself neither when charging is
complete nor when the USB cable is unplugged.

Fixes: https://github.com/baskerville/plato/issues/175