### PR TITLE
Add handling for HTML void tags

### DIFF
--- a/src/document/epub/mod.rs
+++ b/src/document/epub/mod.rs
@@ -63,7 +63,7 @@ impl EpubDocument {
             let mut zf = archive.by_name("META-INF/container.xml")?;
             let mut text = String::new();
             zf.read_to_string(&mut text)?;
-            let root = XmlParser::new(&text).parse();
+            let root = XmlParser::new(&text, false).parse();
             root.find("rootfile")
                 .and_then(|e| e.attr("full-path"))
                 .map(String::from)
@@ -79,7 +79,7 @@ impl EpubDocument {
             text
         };
 
-        let info = XmlParser::new(&text).parse();
+        let info = XmlParser::new(&text, false).parse();
         let mut spine = Vec::new();
 
         {
@@ -269,7 +269,7 @@ impl EpubDocument {
                 let mut zf = self.archive.by_name(name).ok()?;
                 zf.read_to_string(&mut text).ok()?;
             }
-            let root = XmlParser::new(&text).parse();
+            let root = XmlParser::new(&text, false).parse();
             self.cache_uris(&root, name, start_offset, cache);
             cache.get(uri).cloned()
         } else {
@@ -328,7 +328,7 @@ impl EpubDocument {
             }
         }
 
-        let mut root = XmlParser::new(&text).parse();
+        let mut root = XmlParser::new(&text, false).parse();
         root.wrap_lost_inlines();
 
         let mut stylesheet = Vec::new();
@@ -636,7 +636,7 @@ impl Document for EpubDocument {
             return None;
         }
 
-        let root = XmlParser::new(&text).parse();
+        let root = XmlParser::new(&text, false).parse();
         root.find("navMap").map(|map| {
             let mut cache = FxHashMap::default();
             let mut index = 0;

--- a/src/document/html/mod.rs
+++ b/src/document/html/mod.rs
@@ -58,8 +58,10 @@ impl HtmlDocument {
         let size = file.metadata()?.len() as usize;
         let mut text = String::new();
         file.read_to_string(&mut text)?;
-        let mut content = XmlParser::new(&text).parse();
+        let mut content = XmlParser::new(&text, true).parse();
+        println!("Parsed content is {:#?}", content);
         content.wrap_lost_inlines();
+        println!("Wrapped content is {:#?}", content);
         let parent = path.as_ref().parent().unwrap_or_else(|| Path::new(""));
 
         Ok(HtmlDocument {
@@ -77,8 +79,10 @@ impl HtmlDocument {
 
     pub fn new_from_memory(text: &str) -> HtmlDocument {
         let size = text.len();
-        let mut content = XmlParser::new(text).parse();
+        let mut content = XmlParser::new(text, true).parse();
+        println!("Parsed content is {:#?}", content);
         content.wrap_lost_inlines();
+        println!("Wrapped content is {:#?}", content);
 
         HtmlDocument {
             text: text.to_string(),
@@ -95,7 +99,7 @@ impl HtmlDocument {
 
     pub fn update(&mut self, text: &str) {
         self.size = text.len();
-        self.content = XmlParser::new(text).parse();
+        self.content = XmlParser::new(text, true).parse();
         self.content.wrap_lost_inlines();
         self.text = text.to_string();
         self.pages.clear();

--- a/src/document/html/style.rs
+++ b/src/document/html/style.rs
@@ -14,8 +14,8 @@ mod tests {
 
     #[test]
     fn simple_style() {
-        let xml1 = XmlParser::new("<a class='c x y' style='c: 7'/>").parse();
-        let xml2 = XmlParser::new("<a id='e' class='x y'/>").parse();
+        let xml1 = XmlParser::new("<a class='c x y' style='c: 7'/>", false).parse();
+        let xml2 = XmlParser::new("<a id='e' class='x y'/>", false).parse();
         let (mut css1, _) = CssParser::new("a { b: 23 }").parse(RuleKind::Viewer);
         let (mut css2, _) = CssParser::new(".c.x.y { b: 6 }").parse(RuleKind::Document);
         let (mut css3, _) = CssParser::new(".y { b: 2 }").parse(RuleKind::Document);

--- a/src/document/html/xml.rs
+++ b/src/document/html/xml.rs
@@ -93,7 +93,7 @@ impl<'a> XmlParser<'a> {
                 if self.html {
                     match name {
                         "area"|"base"|"br"|"col"|"command"|"embed"|"hr"|"img"|"input"|"keygen"|"link"|"meta"|"param"|"source"|"track"|"wbr" => {
-                            self.advance(2);
+                            self.advance(1);
                             nodes.push(element(name, offset - 1, attributes, Vec::new()));
                         },
                         _ => {


### PR DESCRIPTION
* adds an 'html' bool flag to XmlParser
* when true, handles void elements (those defined as never being allowed to have content) the same way as it handles self-closing elements

List of void elements is from the W3 spec: https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements
Fixes #180 