### PR TITLE
Discover battery from sysfs

### DIFF
--- a/src/battery/kobo.rs
+++ b/src/battery/kobo.rs
@@ -1,12 +1,9 @@
-use std::env;
-use std::fs::File;
-use std::path::Path;
+use std::fs::{File, read_dir, read_to_string};
 use std::io::{Read, Seek, SeekFrom};
 use super::{Battery, Status};
 use anyhow::{Error, format_err};
 
-const BATTERY_INTERFACE_A: &str = "/sys/class/power_supply/mc13892_bat";
-const BATTERY_INTERFACE_B: &str = "/sys/class/power_supply/battery";
+const BATTERY_INTERFACE: &str = "/sys/class/power_supply";
 
 const BATTERY_CAPACITY: &str = "capacity";
 const BATTERY_STATUS: &str = "status";
@@ -19,17 +16,13 @@ pub struct KoboBattery {
 
 impl KoboBattery {
     pub fn new() -> Result<KoboBattery, Error> {
-        let mut firmware_version = [0u16; 3];
-        env::var("FIRMWARE_VERSION").ok()
-            .map(|s| s.split('.')
-                      .filter_map(|v| v.parse::<u16>().ok())
-                      .zip(firmware_version.iter_mut())
-                      .for_each(|(a, b)| *b = a));
-        let base = if firmware_version < [4, 28, 17623] {
-            Path::new(BATTERY_INTERFACE_A)
-        } else {
-            Path::new(BATTERY_INTERFACE_B)
-        };
+        let base = read_dir(BATTERY_INTERFACE)?
+            .filter_map(Result::ok)
+            .map(|dir| dir.path())
+            .find(|path| {
+                let kind = read_to_string(path.join("type")).unwrap_or_default();
+                kind.trim_end() == "Battery"
+            }).expect("Could not find battery");
         let capacity = File::open(base.join(BATTERY_CAPACITY))?;
         let status = File::open(base.join(BATTERY_STATUS))?;
         Ok(KoboBattery { capacity, status })


### PR DESCRIPTION
Hi,

this patch discovers battery status directory in sysfs based on the `type` attribute, avoiding the need to specify driver names for different models / firmware versions.

Some background: I’m using [postmarketOS](https://gitlab.com/postmarketOS/pmaports/-/merge_requests/2334/) with the (close to) [mainline kernel](https://github.com/akemnade/linux) on Kobo Clara HD. I’ve been able to compile and run Plato on it, and it works beautifully. Some changes to the code are needed though; one is addressed by this PR.

The upstreamed battery driver has been renamed to `rn5t618-battery`. With this patch the same code should work on all devices and kernels, even if a new driver name is used in the future (I don’t have other devices to test with though). The only downside is a couple more syscalls at start.

Some other tweaks are needed to run Plato on a mainline kernel and a non-glibc distribution. I’m submitting this first because avoiding hardcoded names (and a dependency on environment values) seems useful in itself. If you agree, I’d like to send further patches to improve compatibility with mainline, at least where it’s possible to do so without affecting the current use cases.

Thanks!