### PR TITLE
Add dictionary download links

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -4,17 +4,34 @@ Pick one of the [one-click install packages](https://www.mobileread.com/forums/s
 
 ## Configure
 
+### Settings
+
 The settings are saved in and read from `Settings.toml`. You can edit this file when *Plato* isn't running or is in shared mode. You can enter the shared mode by connecting your device to a computer.
 
 You can also edit `Settings-sample.toml` and rename it to `Settings.toml` before you first run *Plato*.
 
 `plato.sh` has a few settings that you can override by with `config.sh` (use `config-sample.sh` as a starting point).
 
+### Style Sheets
+
 The following style sheets : `css/{epub,html,dictionary}.css` can be overridden via `css/{epub,html,dictionary}-user.css`.
+
+### Hyphenation Bounds
 
 The hyphenation bounds for a particular language can be overridden by creating a file name `LANGUAGE_CODE.bounds` in the `hyphenation-patterns` directory. The content of this file must the minimum number of letters before the hyphenation point relative to the beginning and end of the word, separated by a space. You can disable hyphenation all together by uncommenting the corresponding line in `config.sh`.
 
+### Dictionaries
+
 Dictionaries in the *StarDict* and *dictd* formats can be placed in the `dictionaries` directory. *Plato* doesn't support *StarDict* natively and will therefore convert all the *StarDict* dictionaries it might find in the `dictionaries` directory during startup. You can disable this behavior by uncommenting the corresponding line in `config.sh`.
+
+For example, these sites provide dictionaries in the *dictd* format:
+
+- [dictinfo.com](https://dictinfo.com) (based on [Wikitionary](https://www.wiktionary.org))
+- [FreeDict](https://freedict.org/downloads)
+
+Download the desired archive and extract the `.dict.dz` and `.index` files to Plato's `dictionaries` directory.
+
+### WiFi Scripts
 
 The four scripts `scripts/wifi-{pre,post}-{up,down}.sh` can be created with commands to run before or after the WiFi is enabled or disabled, respectively.
 


### PR DESCRIPTION
The guide mentions StarDict and dictd, but there's no mention of places to get these. I avoided StarDict since it's not natively supported, so went looking for DICT/dictd format dictionaries. It's somewhat difficult to search for since "dict" is very generic and a lot of the results for "dictd" end up being Debian packages and such. I eventually ended up at the Arch wiki for dictd, which lead me to all the [AUR dictd packages](https://aur.archlinux.org/packages/?O=0&SeB=nd&K=dictd&outdated=&SB=n&SO=a&PP=50&do_Search=Go), which finally lead me to two sources that seem pretty good.

All that is to say, it's a bit of a hassle to figure this all out from scratch. So this PR tries to fill that gap a little more to make it less confusing. Personally I ended up going with the English-only Wikitionary dict from dictinfo.com and it seems to be working well. If there are better sources, though, I'd love to hear.