### PR TITLE
link to linaro release instead of broken Kobo repo for compiler toolchain

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -17,7 +17,7 @@ There are two ways to build *Plato*:
 
 #### Preliminary
 
-Install the appropriate [compiler toolchain](https://github.com/kobolabs/Kobo-Reader/tree/master/toolchain) (the binaries of the `bin` directory need to be in your path).
+Install the [compiler toolchain (gcc-linaro-4.9.4-2017.01)](https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/) (the binaries of the `bin` directory need to be in your path).
 
 Install the required dependencies: `wget`, `curl`, `git`, `pkg-config`, `unzip`, `jq`, `patchelf`.
 


### PR DESCRIPTION
The linked sources of the compiler toolchain are inaccessible.

The files in the repo are links to git large file storage
```
[I] david@darvid-pc ~/P/w/p/K/toolchain (master)> cat gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz 
version https://git-lfs.github.com/spec/v1
oid sha256:22914118fd963f953824b58107015c6953b5bbdccbdcf25ad9fd9a2f9f11ac07
size 80881572

[I] david@darvid-pc ~/P/w/p/K/toolchain (master) [2]> cat gcc-linaro-4.9.4-2017.01-20170615_darwin.tar.bz2 
version https://git-lfs.github.com/spec/v1
oid sha256:ad23f8252fcab0af1dc4fc2f758ec29dbe73c5b29b1589d5b8a7bf5483887ff4
size 132853143
```

But trying to fetch them results in this error
```
[I] david@darvid-pc ~/P/w/p/K/toolchain (master) [1]> git lfs fetch
fetch: Fetching reference refs/heads/master
batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.                
error: failed to fetch some objects from 'https://github.com/kobolabs/Kobo-Reader.git/info/lfs'
[I] david@darvid-pc ~/P/w/p/K/toolchain (master) [2]> 
```

This issue https://github.com/baskerville/plato/issues/164 pointed me towards this source.
It's unfortunate that it doesn't have a Darwin release like the kobo repo did, but neither are accessible at this point anyway.