### PR TITLE
Trim word on dictionary long-press

### DIFF
--- a/src/view/dictionary/mod.rs
+++ b/src/view/dictionary/mod.rs
@@ -444,7 +444,8 @@ impl View for Dictionary {
             },
             Event::Gesture(GestureEvent::HoldFingerLong(pt, _)) => {
                 if let Some(text) = self.underlying_word(pt) {
-                    self.define(Some(&text), rq, context);
+                    let query = text.trim_matches(|c: char| !c.is_alphanumeric()).to_string();
+                    self.define(Some(&query), rq, context);
                 }
                 true
             },


### PR DESCRIPTION
Make the long-press in the dictionary app work like it does within the
reader, where surrounding non-alphanumeric characters are removed.