### PR TITLE
Small fix: Potential dead-lock

### DIFF
--- a/src/framebuffer/image.rs
+++ b/src/framebuffer/image.rs
@@ -127,7 +127,11 @@ impl Framebuffer for Pixmap {
         false
     }
 
-    fn dims(&self) -> (u32, u32) {
-        (self.width, self.height)
+    fn width(&self) -> u32 {
+        self.width
+    }
+    
+    fn height(&self) -> u32 {
+        self.height
     }
 }

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -46,6 +46,8 @@ pub trait Framebuffer {
     fn monochrome(&self) -> bool;
     fn dithered(&self) -> bool;
     fn inverted(&self) -> bool;
+    fn width(&self) -> u32;
+    fn height(&self) -> u32;
 
     fn toggle_inverted(&mut self) {
         self.set_inverted(!self.inverted());
@@ -61,16 +63,6 @@ pub trait Framebuffer {
 
     fn rotation(&self) -> i8 {
         0
-    }
-
-    fn width(&self) -> u32 {
-        let (width, _) = self.dims();
-        width
-    }
-
-    fn height(&self) -> u32 {
-        let (_, height) = self.dims();
-        height
     }
 
     fn dims(&self) -> (u32, u32) {


### PR DESCRIPTION
If neither width()/height() and dims() is implemented, the default trait functions will keep referencing each other.

Rust seems fine to compile this when Pixmap has none of these methods. That would most likely result in a resolution-less framebuffer that locks up when asked for it's resolution.