### PR TITLE
Correct frontlight system path for Kobo Libra 2

### DIFF
--- a/src/frontlight/premixed.rs
+++ b/src/frontlight/premixed.rs
@@ -9,9 +9,9 @@ const FRONTLIGHT_WHITE: &str = "/sys/class/backlight/mxc_msp430.0/brightness";
 
 // Forma
 const FRONTLIGHT_ORANGE_A: &str = "/sys/class/backlight/tlc5947_bl/color";
-// Libra H₂O, Clara HD, Libra 2
+// Libra H₂O, Clara HD
 const FRONTLIGHT_ORANGE_B: &str = "/sys/class/backlight/lm3630a_led/color";
-// Sage
+// Sage, Libra 2
 const FRONTLIGHT_ORANGE_C: &str =  "/sys/class/leds/aw99703-bl_FL1/color";
 
 pub struct PremixedFrontlight {
@@ -27,8 +27,8 @@ impl PremixedFrontlight {
         let model = CURRENT_DEVICE.model;
         let orange_path = match model {
             Model::Forma | Model::Forma32GB => FRONTLIGHT_ORANGE_A,
-            Model::LibraH2O | Model::ClaraHD | Model::Libra2 => FRONTLIGHT_ORANGE_B,
-            Model::Sage => FRONTLIGHT_ORANGE_C,
+            Model::LibraH2O | Model::ClaraHD => FRONTLIGHT_ORANGE_B,
+            Model::Sage | Model::Libra2 => FRONTLIGHT_ORANGE_C,
             _ => FRONTLIGHT_ORANGE_A,
         };
         let orange = OpenOptions::new().write(true).open(orange_path)?;


### PR DESCRIPTION
fixes #238