### PR TITLE
Emulator poll for SDL events

### DIFF
--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -270,7 +270,7 @@ fn main() -> Result<(), Error> {
 
     'outer: loop {
         let mut event_pump = sdl_context.event_pump().unwrap();
-        if let Some(sdl_evt) = event_pump.wait_event_timeout(20) {
+        while let Some(sdl_evt) = event_pump.poll_event() {
             match sdl_evt {
                 SdlEvent::Quit { .. } |
                 SdlEvent::KeyDown { keycode: Some(Keycode::Escape), keymod: Mod::NOMOD, .. } => {


### PR DESCRIPTION
The emulator was ridiculously slow without this change.

Imagine dragging your mouse 100px over the emulator, you would queue up 100 `MouseMotion` events to be processed.

These SDL events were previously being waited on (ONE AT A TIME) in the main thread then queued for gesture recognition. The main thread would then immediately block for 20ms on a gesture which wasn't ready yet. This would process each event, taking 20ms each, until a gesture was finally fired.

Instead of waiting for single SDL events, we should send everything we have straight off to gesture recognition. Then we can wait for the gesture to be processed.

This shouldn't consume any more CPU since we still have a 20ms wait for gestures. We've just changed the app to be eager to process events and happy to wait for gestures.

Fixes #225