### PR TITLE
Allow to star articles and sync stars to Wallabag

### DIFF
--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -199,6 +199,7 @@ pub struct ReaderInfo {
     pub current_page: usize,
     pub pages_count: usize,
     pub finished: bool,
+    pub starred: bool,
     pub dithered: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zoom_mode: Option<ZoomMode>,
@@ -273,6 +274,7 @@ impl Default for ReaderInfo {
             current_page: 0,
             pages_count: 1,
             finished: false,
+            starred: false,
             dithered: false,
             zoom_mode: None,
             scroll_mode: None,
@@ -360,6 +362,13 @@ impl Info {
             }
         } else {
             SimpleStatus::New
+        }
+    }
+
+    pub fn starred(&self) -> bool {
+        match &self.reader {
+            None => false,
+            Some(info) => info.starred,
         }
     }
 

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -524,6 +524,7 @@ pub enum EntryId {
     SelectDirectory(PathBuf),
     ToggleSelectDirectory(PathBuf),
     SetStatus(PathBuf, SimpleStatus),
+    SetStarred(PathBuf, bool),
     SearchAuthor(String),
     RemovePreset(usize),
     FirstColumn(FirstColumn),

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -235,6 +235,9 @@ fn main() -> Result<(), Error> {
     if context.settings.import.startup_trigger {
         context.batch_import();
     }
+    if context.settings.wifi {
+        context.online = true;
+    }
 
     context.load_dictionaries();
     context.load_keyboard_layouts();


### PR DESCRIPTION
First PR to implement https://github.com/baskerville/plato/issues/318, can be reviewed commit by commit:

- ~First commit fixes #300 that I also encountered on ArchLinux. I am not sure whether all distros run into this issue, so I added a `DYNAMIC_MUPDF` envvar for now~ -> rebased and removed
- Second fixes a bug where if the emulator settings hold `wifi = true`, the network does never come as `online`, and the fetcher never executes
- Third adds the `starred` field to ReaderInfo and a menu entry to toggle it
- Fourth makes the fetcher add stars when archiving articles in Wallabag. As proposed in the issue, it's only adding stars for now, not removing them

Feel free to directly push changes to the branch if it's easier for you!