### PR TITLE
Allow overriding individual file type's refresh rates

### DIFF
--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -147,9 +147,8 @@ stretch-tolerance = 1.26
 regular = 8
 inverted = 2
 
-# Override the refresh rate for individual file types.
-[reader.refresh-rate.file-types]
-epub = { regular = 8, inverted = 2 }
+# Override the refresh rate for individual file types (cbz, epub, etc.).
+[reader.refresh-rate.refresh-kinds]
 cbz = { regular = 1, inverted = 1 }
 
 [import]

--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -147,6 +147,11 @@ stretch-tolerance = 1.26
 regular = 8
 inverted = 2
 
+# Override the refresh rate for individual file types.
+[reader.refresh-rate.file-types]
+epub = { regular = 8, inverted = 2 }
+cbz = { regular = 1, inverted = 1 }
+
 [import]
 # Start the import process when the device is unplugged from a computer.
 unshare-trigger = true

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::ops::Index;
 use std::fmt::{self, Debug};
 use std::path::PathBuf;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use fxhash::FxHashSet;
 use serde::{Serialize, Deserialize};
 use crate::metadata::{SortMethod, TextAlign};
@@ -311,6 +311,7 @@ pub struct HomeSettings {
 pub struct RefreshRateSettings {
     pub regular: u8,
     pub inverted: u8,
+    pub file_types: HashMap<String, RefreshRateSettings>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -404,6 +405,7 @@ impl Default for RefreshRateSettings {
         RefreshRateSettings {
             regular: 8,
             inverted: 2,
+            file_types: HashMap::new(),
         }
     }
 }

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -311,7 +311,15 @@ pub struct HomeSettings {
 pub struct RefreshRateSettings {
     pub regular: u8,
     pub inverted: u8,
-    pub file_types: HashMap<String, RefreshRateSettings>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub refresh_kinds: HashMap<String, FileRefreshRateSettings>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct FileRefreshRateSettings {
+    pub regular: u8,
+    pub inverted: u8,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -405,7 +413,9 @@ impl Default for RefreshRateSettings {
         RefreshRateSettings {
             regular: 8,
             inverted: 2,
-            file_types: HashMap::new(),
+            refresh_kinds: HashMap::from([
+                ("cbz".to_string(), FileRefreshRateSettings { regular: 1, inverted: 1 })
+            ]),
         }
     }
 }

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -1033,11 +1033,24 @@ impl Reader {
     fn update(&mut self, update_mode: Option<UpdateMode>, hub: &Hub, rq: &mut RenderQueue, context: &Context) {
         self.page_turns += 1;
         let update_mode = update_mode.unwrap_or_else(|| {
-            let refresh_rate = if context.fb.inverted() {
-                context.settings.reader.refresh_rate.inverted
-            } else {
-                context.settings.reader.refresh_rate.regular
+            let file_refresh_settings = context.settings.reader.refresh_rate.file_types.get(&self.info.file.kind);
+            let refresh_rate = match file_refresh_settings {
+                Some(settings) => {
+                    if context.fb.inverted() {
+                        settings.inverted
+                    } else {
+                        settings.regular
+                    }
+                }
+                None => {
+                    if context.fb.inverted() {
+                        context.settings.reader.refresh_rate.inverted
+                    } else {
+                        context.settings.reader.refresh_rate.regular
+                    }
+                }
             };
+
             if refresh_rate == 0 || self.page_turns % (refresh_rate as usize) != 0 {
                 UpdateMode::Partial
             } else {

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -1033,7 +1033,7 @@ impl Reader {
     fn update(&mut self, update_mode: Option<UpdateMode>, hub: &Hub, rq: &mut RenderQueue, context: &Context) {
         self.page_turns += 1;
         let update_mode = update_mode.unwrap_or_else(|| {
-            let file_refresh_settings = context.settings.reader.refresh_rate.file_types.get(&self.info.file.kind);
+            let file_refresh_settings = context.settings.reader.refresh_rate.refresh_kinds.get(&self.info.file.kind);
             let refresh_rate = match file_refresh_settings {
                 Some(settings) => {
                     if context.fb.inverted() {


### PR DESCRIPTION
Adds a new setting to change the refresh rate based on a documents file type.

```toml
# Override the refresh rate for individual file types.
[reader.refresh-rate.file-types]
epub = { regular = 8, inverted = 2 }
cbz = { regular = 1, inverted = 1 }
```

The motivation for this is that I prefer partial refreshes for text heavy content like .epub's but want full refreshes for .cbz to prevent ghosting from comic/manga panels.