### PR TITLE
Try to explain that `font-path` is specifically for *custom* fonts

### DIFF
--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -109,7 +109,8 @@ east-strip = "next-page"
 # Launch the *Touch Events* application to display the current touch regions.
 strip-width = 0.6
 corner-width = 0.4
-# The path for the user's font directory.
+# The path for the user's custom font directory. Note: this does not exist by
+# default.
 font-path = "/mnt/onboard/fonts"
 # The default serif font.
 font-family = "Libertinus Serif"


### PR DESCRIPTION
I am not the only person who mistakenly thought that `/mnt/onboard/fonts` is supposed to always exist, and should contain a number of fonts out of the box. See this bit of confusion for why I think this comment would be helpful:
https://github.com/baskerville/plato/issues/88#issuecomment-1791947072