### PR TITLE
Add screen lock functionality, unlocked by pressing both forward and back buttons simultaneously

### DIFF
--- a/crates/core/src/view/common.rs
+++ b/crates/core/src/view/common.rs
@@ -105,6 +105,8 @@ pub fn toggle_main_menu(view: &mut dyn View, rect: Rectangle, enable: Option<boo
                                EntryKind::SubMenu("Rotate".to_string(), rotate),
                                EntryKind::Command("Take Screenshot".to_string(),
                                                   EntryId::TakeScreenshot),
+                               EntryKind::Command("Lock Screen Input".to_string(),
+                                                  EntryId::LockScreenInput),
                                EntryKind::Separator,
                                EntryKind::SubMenu("Applications".to_string(), apps),
                                EntryKind::Separator];

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -575,6 +575,7 @@ pub enum EntryId {
     New,
     Refresh,
     TakeScreenshot,
+    LockScreenInput,
     Reboot,
     Quit,
 }


### PR DESCRIPTION
# Motivation

I have a waterproof Kobo Libra H2O. In the rain or shower, water generates touch events on the screen. I want a way to disable these temporarily and only use the buttons.

The functionality is accessible inside the reader, select the top bar and select "Lock Screen Input". Then the screen is disabled, but you can still navigate using the buttons. Pressing them together unlocks the screen.

# Core Organization

Most of the code is implemented in the top level plato and emulator apps. The code is duplicated, so I'd appreciate advise on where to put them. I added a `LockScreenInput` event, which sets a boolean, and then sends `Event::Toggle(ViewId::TopBottomBars)`.

When the boolean `is_screen_locked` is set, then all Gesture events are caught and skipped. Lmk if this is the correct way to do this.

Apart from that, there's a bit of logic to handle pressing both buttons together.

