### PR TITLE
docs: move highlight swipe to simultaneous sequences

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -114,7 +114,6 @@ The following swipe sequences are recognized:
 - Arrow west/east: go to the previous/next chapter in normal mode, the first/last results in search mode.
 - Arrow north/south: start searching text backward/forward.
 - Top left/right corner: go to the previous/next bookmark.
-- Top left/right multi-corner: go to the previous/next annotation or highlight.
 - Bottom left corner: guess the frontlight if there's more than two frontlight presets defined, toggle the frontlight otherwise.
 - Bottom right corner: toggle the dithering mode.
 
@@ -122,6 +121,7 @@ Simultaneous swipe sequences:
 
 - Cross (east arrow with the left hand, west arrow with the right hand): go back to the home screen.
 - Diamond (west arrow with the left hand, east arrow with the right hand): toggle the top and bottom bars.
+- Top left/right multi-corner: go to the previous/next annotation or highlight.
 
 ### Text Selection
 


### PR DESCRIPTION
This change moves the `highlight/annotation` swipe line to simultaneous sequences in `MANUAL.md` to make it less ambigious.

Closes #350.