### PR TITLE
Print explicit information on MuPDF Fitz count_pages error

### DIFF
--- a/crates/core/src/document/pdf.rs
+++ b/crates/core/src/document/pdf.rs
@@ -166,7 +166,16 @@ impl Document for PdfDocument {
     }
 
     fn pages_count(&self) -> usize {
-        unsafe { mp_count_pages(self.ctx.0, self.doc) as usize }
+        unsafe {
+            let page_count: i32 = mp_count_pages(self.ctx.0, self.doc);
+
+            if page_count <= 0 {
+                eprintln!("Error: MuPDF Fitz count_pages function returned {}.", page_count);
+                return 0;
+            }
+
+            return page_count as usize;
+        }
     }
 
     fn resolve_location(&mut self, loc: Location) -> Option<usize> {

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -295,6 +295,8 @@ impl Reader {
                 doc.set_ignore_document_css(true);
             }
 
+            println!("{}", info.file.path.display());
+
             let first_location = doc.resolve_location(Location::Exact(0))?;
 
             let mut view_port = ViewPort::default();
@@ -357,8 +359,6 @@ impl Reader {
 
             let synthetic = doc.has_synthetic_page_numbers();
             let reflowable = doc.is_reflowable();
-
-            println!("{}", info.file.path.display());
 
             hub.send(Event::Update(UpdateMode::Partial)).ok();
 


### PR DESCRIPTION
The change makes sure when user selects a book, the application prints file's path even if there is a problem on the process, it also prints an information about MuPDF's fz_count_pages function error.

Related to #376.